### PR TITLE
Upload Verification Report in the CI

### DIFF
--- a/.github/workflows/gobra.yml
+++ b/.github/workflows/gobra.yml
@@ -72,6 +72,6 @@ jobs:
       - name: Upload the verification report
         uses: actions/upload-artifact@v2
         with:
-          name: verification_statistics
+          name: stats_addr.json
           path: /stats/stats_addr.json
           if-no-files-found: error # could also be 'warn' or 'ignore'


### PR DESCRIPTION
The goal here is to to fix the error "No files were found with the provided path: /home/runner/work/VerifiedSCION/VerifiedSCION/.gobra/stats.json. No artifacts will be uploaded." in the step "Upload the verification report"