### PR TITLE
Context package specification

### DIFF
--- a/verification/dependencies/context/context.gobra
+++ b/verification/dependencies/context/context.gobra
@@ -35,7 +35,7 @@ type Context interface {
 	preserves acc(Mem(), definitions.ReadL20)
 	ensures isClosed ==> c.Closed()
 	ensures (!isClosed && c != nil) ==>
-		acc(c.RecvChannel(), definitions.ReadL20)
+		acc(c.RecvChannel(), _)
 	decreases
 	Done() (c <-chan struct{}, ghost isClosed bool)
 
@@ -47,7 +47,6 @@ type Context interface {
 	preserves acc(Mem(), definitions.ReadL20)
 	requires acc(key.Mem(), _)
 	requires isComparable(key)
-	ensures acc(key.Mem(), _)
 	ensures acc(val.Mem(), _)
 	decreases
 	Value(key interface{ pred Mem() }) (val interface{ pred Mem() })
@@ -59,7 +58,6 @@ requires isComparable(key)
 requires acc(val.Mem(), _)
 ensures child.Mem()
 ensures child.Mem() --* parent.Mem()
-ensures acc(val.Mem(), _)
 decreases _
 func WithValue(parent Context, key, val interface{ pred Mem() }) (child Context)
 


### PR DESCRIPTION
Here is the initial outline of the specification of the context package. There are still things to be changed and some main questions lie in the following areas:

- Should the `Done` method be labeled as `pure`? The downside is we cannot introduce the ghost return value indicating whether or not the channel was previously closed. The specification for the returned channel also needs to be refined but I am ignoring that for now.

- The `Err` method internally obtains and releases a mutex. A Context is safe to pass to multiple goroutines and from the view of the caller, *could* in theory only require read access to the `Mem` predicate. The question here is if that is actually sound. 

- The `Value` method (and consequently `WithValue` function) currently requires that the `key` be a primitive type. However, according to the Go docs using a primitive type should be avoided and in the Scion project, the keys are only used with a new type declaration similar to the below snippet. Thus, enforcing a primitive type will not work.
```go
type loggerContextKey string
```


- The last three functions: `WithDeadline`, `WithTimeout`, and `WithCancel` all return a cancel function. We would need support for closures in order to specify this (I think). What I am most unsure about is, that calling this function should release all resources held by the context but this effect would also change the return values of the methods Err, and Done. 
