### PR TITLE
Add spec of `encoding.binary`

### DIFF
--- a/verification/dependencies/bytes/binary/binary.gobra
+++ b/verification/dependencies/bytes/binary/binary.gobra
@@ -29,20 +29,16 @@ type ByteOrder interface {
 	// decreases
 	pure Uint64(b []byte) (res uint64)
 
-	requires acc(&b[0]) && acc(&b[1])
-	ensures acc(&b[0]) && acc(&b[1])
+	preserves acc(&b[0]) && acc(&b[1])
 	decreases
 	PutUint16(b []byte, uint16)
 
-	requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
-	ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+	preserves acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
 	decreases
 	PutUint32(b []byte, uint32)
 
-	requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
-	requires acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
-	ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
-	ensures acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+	preserves acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+	preserves acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
 	decreases
 	PutUint64(b []byte, uint64)
 
@@ -74,8 +70,7 @@ pure func (e littleEndian) Uint16(b []byte) (res uint16) {
 	return uint16(b[0]) | uint16(b[1])<<8
 }
 
-requires acc(&b[0]) && acc(&b[1])
-ensures acc(&b[0]) && acc(&b[1])
+preserves acc(&b[0]) && acc(&b[1])
 decreases
 func (e littleEndian) PutUint16(b []byte, v uint16) {
 	b[0] = byte(v)
@@ -90,8 +85,7 @@ pure func (e littleEndian) Uint32(b []byte) (res uint32) {
 	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
 }
 
-requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
-ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+preserves acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
 decreases
 func (e littleEndian) PutUint32(b []byte, v uint32) {
 	b[0] = byte(v)
@@ -110,10 +104,8 @@ pure func (e littleEndian) Uint64(b []byte) (res uint64) {
 		uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
 }
 
-requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
-requires acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
-ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
-ensures acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+preserves acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+preserves acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
 decreases
 func (e littleEndian) PutUint64(b []byte, v uint64) {
 	b[0] = byte(v)
@@ -142,8 +134,7 @@ pure func (e bigEndian) Uint16(b []byte) (res uint16) {
 	return uint16(b[1]) | uint16(b[0])<<8
 }
 
-requires acc(&b[0]) && acc(&b[1])
-ensures acc(&b[0]) && acc(&b[1])
+preserves acc(&b[0]) && acc(&b[1])
 decreases
 func (e bigEndian) PutUint16(b []byte, v uint16) {
 	b[0] = byte(v >> 8)
@@ -158,8 +149,7 @@ pure func (e bigEndian) Uint32(b []byte) (res uint32) {
 	return uint32(b[3]) | uint32(b[2])<<8 | uint32(b[1])<<16 | uint32(b[0])<<24
 }
 
-requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
-ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+preserves acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
 decreases
 func (e bigEndian) PutUint32(b []byte, v uint32) {
 	b[0] = byte(v >> 24)
@@ -178,10 +168,8 @@ pure func (e bigEndian) Uint64(b []byte) (res uint64) {
 		uint64(b[3])<<32 | uint64(b[2])<<40 | uint64(b[1])<<48 | uint64(b[0])<<56
 }
 
-requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
-requires acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
-ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
-ensures acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+preserves acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+preserves acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
 decreases
 func (e bigEndian) PutUint64(b []byte, v uint64) {
 	b[0] = byte(v >> 56)


### PR DESCRIPTION
For some reason, a copy of `encoding/binary` was not made in PR https://github.com/viperproject/VerifiedSCION/pull/13 . This PR introduces our own spec of that package, such that we can iterate on it faster. Compared to the original version, this spec also ensures that the results of calling `UintX` with `X` in {16, 32, 64} is non-negative.