### PR TITLE
Lift assumptions from `extn.go`

### DIFF
--- a/pkg/slayers/extn_spec.gobra
+++ b/pkg/slayers/extn_spec.gobra
@@ -105,9 +105,16 @@ func (h *HopByHopExtnSkipper) LayerPayload(ghost ub []byte) (res []byte) {
 /** end of HopByHopExtnSkipper **/
 
 /** Currently Axiomatized - EndToEndExtn **/
-pred (e *EndToEndExtn) NonInitMem()
+pred (e *EndToEndExtn) NonInitMem() {
+	acc(e)
+}
 
-pred (e *EndToEndExtn) Mem(ubuf []byte)
+pred (e *EndToEndExtn) Mem(ubuf []byte) {
+	e.extnBase.Mem(ubuf) &&
+	acc(&e.Options) &&
+	forall i int :: { &e.Options[i] } 0 <= i && i < len(e.Options) ==>
+		(acc(&e.Options[i]) && e.Options[i].Mem(i))
+}
 
 // Gobra is not able to infer that EndToEndExtn is "inheriting"
 // the implementation of LayerContents from extnBase.
@@ -198,5 +205,14 @@ pred (o *HopByHopOption) Mem(_ int) {
 	// together with the underlying, not in the option itself
 	acc(o) // && slices.AbsSlice_Bytes(o.OptData, 0, len(o.OptData))
 }
+
+// TODO: maybe add the underlying slice as a parameter to be able to
+// establish that OptData aliases with it.
+pred (e *EndToEndOption) Mem(_ int) {
+	// permissions to the elements of OptData will be stored
+	// together with the underlying, not in the option itself
+	acc(e) // && slices.AbsSlice_Bytes(e.OptData, 0, len(e.OptData))
+}
+
 
 /** end of options **/

--- a/pkg/slayers/extn_spec.gobra
+++ b/pkg/slayers/extn_spec.gobra
@@ -47,7 +47,7 @@ pred (h *HopByHopExtn) Mem(ubuf []byte) {
 	h.extnBase.Mem(ubuf) &&
 	acc(&h.Options) &&
 	forall i int :: { &h.Options[i] } 0 <= i && i < len(h.Options) ==>
-		(acc(&h.Options[i]) && h.Options[i].Mem())
+		(acc(&h.Options[i]) && h.Options[i].Mem(i))
 }
 
 // Gobra is not able to infer that HopByHopExtn is "inheriting"
@@ -193,7 +193,7 @@ pure func computeLen(options []*tlvOption, start, end int) (res int) {
 
 // TODO: maybe add the underlying slice as a parameter to be able to
 // establish that OptData aliases with it.
-pred (o *HopByHopOption) Mem() {
+pred (o *HopByHopOption) Mem(_ int) {
 	// permissions to the elements of OptData will be stored
 	// together with the underlying, not in the option itself
 	acc(o) // && slices.AbsSlice_Bytes(o.OptData, 0, len(o.OptData))

--- a/pkg/slayers/extn_spec.gobra
+++ b/pkg/slayers/extn_spec.gobra
@@ -191,6 +191,8 @@ pure func computeLen(options []*tlvOption, start, end int) (res int) {
 
 /** start of options **/
 
+// TODO: maybe add the underlying slice as a parameter to be able to
+// establish that OptData aliases with it.
 pred (o *HopByHopOption) Mem() {
 	// permissions to the elements of OptData will be stored
 	// together with the underlying, not in the option itself


### PR DESCRIPTION
The only methods in extn.go missing are `decodeEndToEndExtn` and `decodeHopByHopExtn`. These are to be handled with the remaining methods in isse #77