### PR TITLE
drop usages of wands that are not strictly necessary (for carbon)

### DIFF
--- a/pkg/slayers/path/scion/base.go
+++ b/pkg/slayers/path/scion/base.go
@@ -73,7 +73,7 @@ type Base struct {
 // @ requires  s.NonInitMem()
 // @ preserves acc(slices.AbsSlice_Bytes(data, 0, len(data)), definitions.ReadL1)
 // @ ensures   r != nil ==> (s.NonInitMem() && r.ErrorMem())
-// @ ensures   r == nil ==> s.Mem() && (s.Mem() --* s.NonInitMem())
+// @ ensures   r == nil ==> s.Mem()
 // @ ensures   len(data) < MetaLen ==> r != nil
 // @ decreases
 func (s *Base) DecodeFromBytes(data []byte) (r error) {
@@ -107,10 +107,6 @@ func (s *Base) DecodeFromBytes(data []byte) (r error) {
 		s.NumHops += int(s.PathMeta.SegLen[i])
 	}
 	//@ fold s.Mem()
-	//@ package s.Mem() --* s.NonInitMem() {
-	//@   unfold s.Mem()
-	//@   fold   s.NonInitMem()
-	//@ }
 	return nil
 }
 

--- a/pkg/slayers/path/scion/base_spec.gobra
+++ b/pkg/slayers/path/scion/base_spec.gobra
@@ -55,3 +55,12 @@ decreases
 pure func (b *Base) getNumHops() (res int) {
 	return unfolding acc(b.Mem(), _) in b.NumHops
 }
+
+ghost
+requires b.Mem()
+ensures  b.NonInitMem()
+decreases
+func (b *Base) DowngradePerm() {
+	unfold b.Mem()
+	fold b.NonInitMem()
+}

--- a/pkg/slayers/path/scion/decoded.go
+++ b/pkg/slayers/path/scion/decoded.go
@@ -57,7 +57,7 @@ func (s *Decoded) DecodeFromBytes(data []byte) (r error) {
 	// (VerifiedSCION) Gobra expects a stronger contract for s.Len() when in fact
 	// what happens here is that we just call the same function in s.Base.
 	if minLen := s. /*@ Base. @*/ Len(); len(data) < minLen {
-		//@ apply s.Base.Mem() --* s.Base.NonInitMem()
+		//@ s.Base.DowngradePerm()
 		//@ fold s.NonInitMem()
 		return serrors.New("DecodedPath raw too short", "expected", minLen, "actual", int(len(data)))
 	}

--- a/pkg/slayers/path/scion/raw.go
+++ b/pkg/slayers/path/scion/raw.go
@@ -47,7 +47,7 @@ func (s *Raw) DecodeFromBytes(data []byte) (res error) {
 	// happens here is that we just call the same function in s.Base.
 	pathLen := s. /*@ Base. @*/ Len()
 	if len(data) < pathLen {
-		//@ apply s.Base.Mem() --* s.Base.NonInitMem()
+		//@ s.Base.DowngradePerm()
 		//@ fold s.NonInitMem()
 		return serrors.New("RawPath raw too short", "expected", pathLen, "actual", int(len(data)))
 	}

--- a/pkg/slayers/scion.go
+++ b/pkg/slayers/scion.go
@@ -288,7 +288,7 @@ func (s *SCION) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeO
 		// @ sl.CombineRange_Bytes(ubuf, CmnHdrLen, len(ubuf), def.ReadL10)
 		// @ sl.SplitRange_Bytes(ubuf, CmnHdrLen+s.AddrHdrLen(nil, true), int(s.HdrLen*LineLen), def.ReadL10)
 		// @ sl.CombineRange_Bytes(uSerBufN, 0, scnLen, writePerm)
-		// @ apply sl.AbsSlice_Bytes(uSerBufN, 0, len(uSerBufN)) --* (b.Mem() && b.UBuf() === uSerBufN)
+		// @ b.RestoreMem(uSerBufN)
 		return err
 	}
 	offset := CmnHdrLen + s.AddrHdrLen( /*@ nil, true @*/ )
@@ -301,7 +301,7 @@ func (s *SCION) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeO
 	tmp := s.Path.SerializeTo(buf[offset:] /*@, pathSlice @*/)
 	// @ sl.CombineRange_Bytes(buf, offset, len(buf), writePerm)
 	// @ sl.CombineRange_Bytes(uSerBufN, 0, scnLen, writePerm)
-	// @ apply sl.AbsSlice_Bytes(uSerBufN, 0, len(uSerBufN)) --* (b.Mem() && b.UBuf() === uSerBufN)
+	// @ b.RestoreMem(uSerBufN)
 	return tmp
 }
 

--- a/pkg/slayers/scmp.go
+++ b/pkg/slayers/scmp.go
@@ -138,7 +138,7 @@ func (s *SCMP) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOp
 	// @ unfold slices.AbsSlice_Bytes(bytes, 0, 2)
 	// @ fold slices.AbsSlice_Bytes(underlyingBufRes, 0, 2)
 	// @ slices.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 2, writePerm)
-	// @ apply slices.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	// @ )
 
 	if opts.ComputeChecksums {
@@ -161,13 +161,13 @@ func (s *SCMP) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOp
 		bytes[3] = 0
 		// @ fold slices.AbsSlice_Bytes(underlyingBufRes, 0, 4)
 		// @ slices.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 4, writePerm)
-		// @ apply slices.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+		// @ b.RestoreMem(underlyingBufRes)
 		// @ )
 		verScionTmp := b.Bytes()
 		// @ unfold s.scn.ChecksumMem()
 		s.Checksum, err = s.scn.computeChecksum(verScionTmp, uint8(L4SCMP))
 		// @ fold s.scn.ChecksumMem()
-		// @ apply slices.AbsSlice_Bytes(verScionTmp, 0, len(verScionTmp)) --* (b.Mem() && b.UBuf() === verScionTmp)
+		// @ b.RestoreMem(verScionTmp)
 		if err != nil {
 			// @ fold s.Mem(ubufMem)
 			return err
@@ -189,7 +189,7 @@ func (s *SCMP) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOp
 	binary.BigEndian.PutUint16(bytes[2:], s.Checksum)
 	// @ fold slices.AbsSlice_Bytes(underlyingBufRes, 0, 4)
 	// @ slices.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 4, writePerm)
-	// @ apply slices.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	// @ )
 	// @ fold s.Mem(ubufMem)
 	return nil

--- a/pkg/slayers/scmp_msg.go
+++ b/pkg/slayers/scmp_msg.go
@@ -138,7 +138,7 @@ func (i *SCMPExternalInterfaceDown) SerializeTo(b gopacket.SerializeBuffer, opts
 	// @ fold sl.AbsSlice_Bytes(newSlice, 0, len(newSlice))
 	// @ sl.CombineRange_Bytes(buf, offset, offset+scmpRawInterfaceLen, writePerm)
 	// @ sl.CombineRange_Bytes(underlyingBufRes, 0, len(buf), writePerm)
-	// @ apply sl.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	return nil
 }
 
@@ -292,7 +292,7 @@ func (i *SCMPInternalConnectivityDown) SerializeTo(b gopacket.SerializeBuffer, o
 	// @ fold sl.AbsSlice_Bytes(newSlice, 0, len(newSlice))
 	// @ sl.CombineRange_Bytes(buf, offset, offset+scmpRawInterfaceLen, writePerm)
 	// @ sl.CombineRange_Bytes(underlyingBufRes, 0, len(buf), writePerm)
-	// @ apply sl.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	return nil
 }
 
@@ -445,7 +445,7 @@ func (i *SCMPEcho) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Seriali
 	binary.BigEndian.PutUint16(buf[:2], i.Identifier)
 	// @ fold sl.AbsSlice_Bytes(underlyingBufRes, 0, 2)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 2, writePerm)
-	// @ apply sl.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	// @ )
 	offset += 2
 	// @ requires offset == 2
@@ -465,7 +465,7 @@ func (i *SCMPEcho) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Seriali
 	// @ fold sl.AbsSlice_Bytes(underlyingBufRes, 2, 4)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 2, len(underlyingBufRes), 4, writePerm)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 2, writePerm)
-	// @ apply sl.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	// @ )
 	return nil
 }
@@ -591,7 +591,7 @@ func (i *SCMPParameterProblem) SerializeTo(b gopacket.SerializeBuffer, opts gopa
 	binary.BigEndian.PutUint16(buf[0:2], uint16(0)) //Reserved
 	// @ fold sl.AbsSlice_Bytes(underlyingBufRes, 0, 2)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 2, writePerm)
-	// @ apply sl.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	// @ )
 	// @ requires  len(underlyingBufRes) >= 4
 	// @ requires  buf === underlyingBufRes[:4]
@@ -609,7 +609,7 @@ func (i *SCMPParameterProblem) SerializeTo(b gopacket.SerializeBuffer, opts gopa
 	// @ fold sl.AbsSlice_Bytes(underlyingBufRes, 2, 4)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 2, len(underlyingBufRes), 4, writePerm)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 2, writePerm)
-	// @ apply sl.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	// @ )
 	return nil
 }
@@ -790,7 +790,7 @@ func (i *SCMPTraceroute) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.S
 	binary.BigEndian.PutUint16(buf[:2], i.Identifier)
 	// @ fold sl.AbsSlice_Bytes(underlyingBufRes, 0, 2)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 2, writePerm)
-	// @ apply sl.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	// @ )
 	offset += 2
 	// @ requires offset == 2
@@ -810,7 +810,7 @@ func (i *SCMPTraceroute) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.S
 	// @ fold sl.AbsSlice_Bytes(underlyingBufRes, 2, 2+2)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 2, len(underlyingBufRes), 2+2, writePerm)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 2, writePerm)
-	// @ apply sl.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	// @ )
 	offset += 2
 	// @ requires offset == 2 + 2
@@ -830,7 +830,7 @@ func (i *SCMPTraceroute) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.S
 	// @ fold sl.AbsSlice_Bytes(underlyingBufRes, 2+2, 2+2+addr.IABytes)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 2+2, len(underlyingBufRes), 2+2+addr.IABytes, writePerm)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 2+2, writePerm)
-	// @ apply sl.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	// @ )
 	offset += addr.IABytes
 	// @ requires offset == 2 + 2 + addr.IABytes
@@ -850,7 +850,7 @@ func (i *SCMPTraceroute) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.S
 	// @ fold sl.AbsSlice_Bytes(underlyingBufRes, 2+2+addr.IABytes, 2+2+addr.IABytes+scmpRawInterfaceLen)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 2+2+addr.IABytes, len(underlyingBufRes), 2+2+addr.IABytes+scmpRawInterfaceLen, writePerm)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 2+2+addr.IABytes, writePerm)
-	// @ apply sl.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	// @ )
 	return nil
 }
@@ -952,7 +952,7 @@ func (i *SCMPDestinationUnreachable) SerializeTo(b gopacket.SerializeBuffer, opt
 	copy(buf, make([]byte, 4) /*@, writePerm@*/)
 	// @ fold sl.AbsSlice_Bytes(underlyingBufRes, 0, 4)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 4, writePerm)
-	// @ apply sl.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	return nil
 }
 
@@ -1078,7 +1078,7 @@ func (i *SCMPPacketTooBig) SerializeTo(b gopacket.SerializeBuffer, opts gopacket
 	binary.BigEndian.PutUint16(buf[0:2], uint16(0)) //Reserved
 	// @ fold sl.AbsSlice_Bytes(underlyingBufRes, 0, 2)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 2, writePerm)
-	// @ apply sl.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	// @ )
 	// @ requires len(underlyingBufRes) >= 4
 	// @ requires buf === underlyingBufRes[:4]
@@ -1096,7 +1096,7 @@ func (i *SCMPPacketTooBig) SerializeTo(b gopacket.SerializeBuffer, opts gopacket
 	// @ fold sl.AbsSlice_Bytes(underlyingBufRes, 2, 4)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 2, len(underlyingBufRes), 4, writePerm)
 	// @ sl.CombineAtIndex_Bytes(underlyingBufRes, 0, len(underlyingBufRes), 2, writePerm)
-	// @ apply sl.AbsSlice_Bytes(underlyingBufRes, 0, len(underlyingBufRes)) --* (b.Mem() && b.UBuf() === underlyingBufRes)
+	// @ b.RestoreMem(underlyingBufRes)
 	// @ )
 	return nil
 }

--- a/verification/dependencies/github.com/google/gopacket/writer.gobra
+++ b/verification/dependencies/github.com/google/gopacket/writer.gobra
@@ -35,6 +35,8 @@ type SerializeOptions struct {
 
 type SerializeBuffer interface {
 	pred Mem()
+	// morally, corresponds to slices.AbsSlice_Bytes(ub, 0, len(ub)) --* (Mem() && UBuf() === ub)
+	pred MemWithoutUBuf(ub []byte)
 
 	ghost
 	pure
@@ -46,14 +48,21 @@ type SerializeBuffer interface {
 	requires Mem()
 	ensures  res === old(UBuf())
 	ensures  slices.AbsSlice_Bytes(res, 0, len(res))
-	ensures  slices.AbsSlice_Bytes(res, 0, len(res)) --* (Mem() && UBuf() === res)
+	ensures  MemWithoutUBuf(res)
 	decreases
 	ExchangePred() (res []byte)
+
+	ghost
+	requires MemWithoutUBuf(ub)
+	requires slices.AbsSlice_Bytes(ub, 0, len(ub))
+	ensures  Mem() && UBuf() === ub
+	decreases
+	RestoreMem(ghost ub []byte)
 
 	requires Mem()
 	ensures  res === old(UBuf())
 	ensures  slices.AbsSlice_Bytes(res, 0, len(res))
-	ensures  slices.AbsSlice_Bytes(res, 0, len(res)) --* (Mem() && UBuf() === res)
+	ensures  MemWithoutUBuf(res)
 	decreases
 	Bytes() (res []byte)
 
@@ -96,7 +105,7 @@ ensures res.Mem()
 decreases
 func NewSerializeBuffer() (res SerializeBuffer)
 
-// TODO: requires changing to provide access to the underluing layers 
+// TODO: requires changes to provide access to the underlying layers
 requires  false
 requires  len(layerBufs) == len(layers)
 preserves w.Mem()


### PR DESCRIPTION
There are still a few magic wands that need to be dealt with in slayers/scion.go (i.e., for methods `SetSrcAddr` and `packAddr`), but addressing this requires a more drastic change. It will be done in a separate PR