### PR TITLE
finish `process`

### DIFF
--- a/pkg/slayers/path/scion/base.go
+++ b/pkg/slayers/path/scion/base.go
@@ -150,8 +150,9 @@ func (s *Base) IsXover() bool {
 
 // IsFirstHopAfterXover returns whether this is the first hop field after a crossover point.
 // @ preserves acc(s.Mem(), definitions.ReadL19)
+// @ ensures   res ==> unfolding acc(s.Mem(), _) in s.PathMeta.CurrINF > 0 && s.PathMeta.CurrHF > 0
 // @ decreases
-func (s *Base) IsFirstHopAfterXover() bool {
+func (s *Base) IsFirstHopAfterXover() (res bool) {
 	//@ unfold acc(s.Mem(), definitions.ReadL19)
 	//@ defer fold acc(s.Mem(), definitions.ReadL19)
 	return s.PathMeta.CurrINF > 0 && s.PathMeta.CurrHF > 0 &&

--- a/pkg/slayers/path/scion/raw.go
+++ b/pkg/slayers/path/scion/raw.go
@@ -191,7 +191,7 @@ func (s *Raw) IncPath( /*@ ghost ubuf []byte @*/ ) (r error) {
 // @ requires  0 <= idx
 // @ preserves acc(slices.AbsSlice_Bytes(ubuf, 0, len(ubuf)), def.ReadL10)
 // @ ensures   acc(s.Mem(ubuf), def.ReadL10)
-// @ ensures   idx < old(s.GetNumINF(ubuf)) ==> err == nil
+// @ ensures   (idx < old(s.GetNumINF(ubuf))) == (err == nil)
 // @ ensures   err != nil ==> err.ErrorMem()
 // @ decreases
 func (s *Raw) GetInfoField(idx int /*@, ghost ubuf []byte @*/) (ifield path.InfoField, err error) {
@@ -218,19 +218,20 @@ func (s *Raw) GetInfoField(idx int /*@, ghost ubuf []byte @*/) (ifield path.Info
 
 // GetCurrentInfoField is a convenience method that returns the current hop field pointed to by the
 // CurrINF index in the path meta header.
-// @ preserves acc(s.Mem(ubuf), def.ReadL1)
+// @ preserves acc(s.Mem(ubuf), def.ReadL8)
 // @ preserves acc(slices.AbsSlice_Bytes(ubuf, 0, len(ubuf)), def.ReadL1)
-// @ ensures r != nil ==> r.ErrorMem()
+// @ ensures   (r == nil) == (s.GetCurrINF(ubuf) < s.GetNumINF(ubuf))
+// @ ensures   r != nil ==> r.ErrorMem()
 // @ decreases
 func (s *Raw) GetCurrentInfoField( /*@ ghost ubuf []byte @*/ ) (res path.InfoField, r error) {
-	//@ unfold acc(s.Mem(ubuf), def.ReadL1)
-	//@ unfold acc(s.Base.Mem(), def.ReadL1)
+	//@ unfold acc(s.Mem(ubuf), def.ReadL9)
+	//@ unfold acc(s.Base.Mem(), def.ReadL10)
 	idx := int(s.PathMeta.CurrINF)
 	// (VerifiedSCION) Cannot assert bounds of uint:
 	// https://github.com/viperproject/gobra/issues/192
 	//@ assume 0 <= idx
-	//@ fold acc(s.Base.Mem(), def.ReadL1)
-	//@ fold acc(s.Mem(ubuf), def.ReadL1)
+	//@ fold acc(s.Base.Mem(), def.ReadL10)
+	//@ fold acc(s.Mem(ubuf), def.ReadL9)
 	return s.GetInfoField(idx /*@, ubuf @*/)
 }
 
@@ -266,7 +267,7 @@ func (s *Raw) SetInfoField(info path.InfoField, idx int /*@, ghost ubuf []byte @
 // @ requires  0 <= idx
 // @ preserves acc(s.Mem(ubuf), def.ReadL10)
 // @ preserves acc(slices.AbsSlice_Bytes(ubuf, 0, len(ubuf)), def.ReadL10)
-// @ ensures   idx < old(s.GetNumHops(ubuf)) ==> r == nil
+// @ ensures   (idx < old(s.GetNumHops(ubuf))) == (r == nil)
 // @ ensures   r != nil ==> r.ErrorMem()
 // @ decreases
 func (s *Raw) GetHopField(idx int /*@, ghost ubuf []byte @*/) (res path.HopField, r error) {
@@ -294,19 +295,20 @@ func (s *Raw) GetHopField(idx int /*@, ghost ubuf []byte @*/) (res path.HopField
 
 // GetCurrentHopField is a convenience method that returns the current hop field pointed to by the
 // CurrHF index in the path meta header.
-// @ preserves acc(s.Mem(ubuf), def.ReadL1)
+// @ preserves acc(s.Mem(ubuf), def.ReadL8)
 // @ preserves acc(slices.AbsSlice_Bytes(ubuf, 0, len(ubuf)), def.ReadL1)
+// @ ensures   (r == nil) == (s.GetCurrHF(ubuf) < s.GetNumHops(ubuf))
 // @ ensures   r != nil ==> r.ErrorMem()
 // @ decreases
 func (s *Raw) GetCurrentHopField( /*@ ghost ubuf []byte @*/ ) (res path.HopField, r error) {
-	//@ unfold acc(s.Mem(ubuf), def.ReadL2)
-	//@ unfold acc(s.Base.Mem(), def.ReadL3)
+	//@ unfold acc(s.Mem(ubuf), def.ReadL9)
+	//@ unfold acc(s.Base.Mem(), def.ReadL10)
 	idx := int(s.PathMeta.CurrHF)
 	// (VerifiedSCION) Cannot assert bounds of uint:
 	// https://github.com/viperproject/gobra/issues/192
 	//@ assume 0 <= idx
-	//@ fold acc(s.Base.Mem(), def.ReadL3)
-	//@ fold acc(s.Mem(ubuf), def.ReadL2)
+	//@ fold acc(s.Base.Mem(), def.ReadL10)
+	//@ fold acc(s.Mem(ubuf), def.ReadL9)
 	return s.GetHopField(idx /*@, ubuf @*/)
 }
 
@@ -344,14 +346,11 @@ func (s *Raw) SetHopField(hop path.HopField, idx int /*@, ghost ubuf []byte @*/)
 }
 
 // IsFirstHop returns whether the current hop is the first hop on the path.
-// @ preserves acc(s.Mem(ubuf), def.ReadL20)
+// @ pure
+// @ requires  acc(s.Mem(ubuf), _)
 // @ decreases
 func (s *Raw) IsFirstHop( /*@ ghost ubuf []byte @*/ ) bool {
-	//@ unfold acc(s.Mem(ubuf), def.ReadL20)
-	//@ defer  fold acc(s.Mem(ubuf), def.ReadL20)
-	//@ unfold acc(s.Base.Mem(), def.ReadL20)
-	//@ defer  fold acc(s.Base.Mem(), def.ReadL20)
-	return s.PathMeta.CurrHF == 0
+	return /*@ unfolding acc(s.Mem(ubuf), _) in (unfolding acc(s.Base.Mem(), _) in @*/ s.PathMeta.CurrHF == 0 /*@ ) @*/
 }
 
 // IsPenultimateHop returns whether the current hop is the penultimate hop on the path.

--- a/pkg/slayers/path/scion/raw_spec.gobra
+++ b/pkg/slayers/path/scion/raw_spec.gobra
@@ -83,6 +83,20 @@ func (s *Raw) IsFirstHopAfterXover(ghost ub []byte) (res bool) {
 	defer fold acc(s.Mem(ub), def.ReadL18)
 	return s.Base.IsFirstHopAfterXover()
 }
+
+/**
+  * This method is not part of the original SCION codebase.
+  * Instead, `IsXover` was defined in `*Base` via embedded structs.
+  * Unfortunately, Gobra does not fully support them yet, so we
+  * introduced this wrapper method which acts as a wrapper.
+  */
+preserves acc(s.Mem(ub), def.ReadL9)
+decreases
+func (s *Raw) IsXover(ghost ub []byte) bool {
+	unfold acc(s.Mem(ub), def.ReadL9)
+	defer fold acc(s.Mem(ub), def.ReadL9)
+	return s.Base.IsXover()
+}
 /**** End of Stubs ****/
 
 /**** Lemmas ****/

--- a/pkg/slayers/path/scion/raw_spec.gobra
+++ b/pkg/slayers/path/scion/raw_spec.gobra
@@ -76,8 +76,9 @@ func (s *Raw) Len(ghost buf []byte) (l int) {
   * introduced this wrapper method which acts as a wrapper.
   */
 preserves acc(s.Mem(ub), def.ReadL18)
+ensures   res ==> 0 < s.GetCurrINF(ub) && 0 < s.GetCurrHF(ub)
 decreases
-func (s *Raw) IsFirstHopAfterXover(ghost ub []byte) bool {
+func (s *Raw) IsFirstHopAfterXover(ghost ub []byte) (res bool) {
 	unfold acc(s.Mem(ub), def.ReadL18)
 	defer fold acc(s.Mem(ub), def.ReadL18)
 	return s.Base.IsFirstHopAfterXover()

--- a/pkg/slayers/scion_spec.gobra
+++ b/pkg/slayers/scion_spec.gobra
@@ -247,6 +247,20 @@ func (s *SCION) GetPath(ub []byte) path.Path {
 }
 
 ghost
+requires  acc(s.Mem(ub), _)
+decreases
+pure func (s *SCION) GetPayloadLen(ghost ub []byte) uint16 {
+    return unfolding acc(s.Mem(ub), _) in s.PayloadLen
+}
+
+ghost
+requires  acc(s.Mem(ub), _)
+decreases
+pure func (s *SCION) GetPayload(ghost ub []byte) []byte {
+    return unfolding acc(s.Mem(ub), _) in s.Payload
+}
+
+ghost
 requires acc(&s.DstAddrType, def.ReadL20) && acc(&s.SrcAddrType, def.ReadL20)
 requires s.DstAddrType.Has3Bits() && s.SrcAddrType.Has3Bits()
 ensures  0 <= res

--- a/router/dataplane_spec.gobra
+++ b/router/dataplane_spec.gobra
@@ -246,6 +246,14 @@ func (d *DataPlane) getBfdSessionsMem() {
 	unfold acc(MutexInvariant!<d!>(), _)
 }
 
+ghost
+requires acc(MutexInvariant!<d!>(), _)
+ensures  acc(&d.internal, _) && (d.internal != nil ==> acc(d.internal.Mem(), _))
+decreases
+func (d *DataPlane) getInternal() {
+	unfold acc(MutexInvariant!<d!>(), _)
+}
+
 /**** End of acessor methods to avoid unfolding the Mem predicate of the dataplane so much ****/
 
 /**** Post-init invariants ****/

--- a/router/dataplane_spec.gobra
+++ b/router/dataplane_spec.gobra
@@ -208,6 +208,22 @@ func (d *DataPlane) getInternalNextHops() {
 
 ghost
 requires acc(MutexInvariant!<d!>(), _)
+ensures  acc(&d.external, _) && (d.external != nil ==> acc(AccBatchConn(d.external), _))
+decreases
+func (d *DataPlane) getExternalMem() {
+	unfold acc(MutexInvariant!<d!>(), _)
+}
+
+ghost
+requires acc(MutexInvariant!<d!>(), _)
+ensures  acc(&d.linkTypes, _) && (d.linkTypes != nil ==> acc(d.linkTypes, _))
+decreases
+func (d *DataPlane) getLinkTypesMem() {
+	unfold acc(MutexInvariant!<d!>(), _)
+}
+
+ghost
+requires acc(MutexInvariant!<d!>(), _)
 ensures  acc(&d.localIA, _)
 decreases
 func (d *DataPlane) getLocalIA() {

--- a/router/dataplane_spec.gobra
+++ b/router/dataplane_spec.gobra
@@ -238,6 +238,14 @@ func (d *DataPlane) getSvcMem() {
 	unfold acc(MutexInvariant!<d!>(), _)
 }
 
+ghost
+requires acc(MutexInvariant!<d!>(), _)
+ensures  acc(&d.bfdSessions, _) && (d.bfdSessions != nil ==> acc(AccBfdSession(d.bfdSessions), _))
+decreases
+func (d *DataPlane) getBfdSessionsMem() {
+	unfold acc(MutexInvariant!<d!>(), _)
+}
+
 /**** End of acessor methods to avoid unfolding the Mem predicate of the dataplane so much ****/
 
 /**** Post-init invariants ****/


### PR DESCRIPTION
This PR proves the memory safety of `process` (except for one small branch for which memory safety will be proven on a separate PR, together with the functional spec that is missing - mostly about the values of type `processResult` that are returned). Ofc, all of this depends on `packSCMP` for which no spec is currently assumed. When that method is finished, we should remove all `def.TODO()` to make sure that the given spec is as permissive as expected