### PR TITLE
Verify `AddHdrLen`

### DIFF
--- a/pkg/slayers/scion.go
+++ b/pkg/slayers/scion.go
@@ -803,17 +803,13 @@ func packAddr(hostAddr net.Addr /*@ , ghost wildcard bool @*/) (addrtyp AddrType
 func (s *SCION) AddrHdrLen( /*@ ghost ubuf []byte, ghost insideSlayers bool @*/ ) (res int) {
 	/*@
 	ghost if !insideSlayers {
+		unfold acc(s.Mem(ubuf), def.ReadL25)
+		defer fold acc(s.Mem(ubuf), def.ReadL25)
+		unfold acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL25)
+		defer fold acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL25)
 		assert s.AddrHdrLenSpec(ubuf) == (
-			unfolding acc(s.Mem(ubuf), _) in
-			unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), _) in
-			2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length())
-		unfold acc(s.Mem(ubuf), def.ReadL20/2)
-		defer fold acc(s.Mem(ubuf), def.ReadL20/2)
-		unfold acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL20/2)
-		defer fold acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL20/2)
-		assert s.AddrHdrLenSpec(ubuf) == (
-			unfolding acc(s.Mem(ubuf), _) in
-			unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), _) in
+			unfolding acc(s.Mem(ubuf), def.ReadL25) in
+			unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL25) in
 			2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length())
 		assert s.AddrHdrLenSpec(ubuf) ==
 			2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length()

--- a/pkg/slayers/scion.go
+++ b/pkg/slayers/scion.go
@@ -793,9 +793,9 @@ func packAddr(hostAddr net.Addr /*@ , ghost wildcard bool @*/) (addrtyp AddrType
 //	This hack will not be needed when we introduce support for
 //	multiple contracts per method.
 //
-// @ preserves insideSlayers  ==> acc(&s.DstAddrType, def.ReadL20) && acc(&s.SrcAddrType, def.ReadL20)
+// @ preserves insideSlayers  ==> acc(&s.DstAddrType, def.ReadL50) && acc(&s.SrcAddrType, def.ReadL50)
 // @ preserves insideSlayers  ==> (s.DstAddrType.Has3Bits() && s.SrcAddrType.Has3Bits())
-// @ preserves !insideSlayers ==> acc(s.Mem(ubuf), def.ReadL20)
+// @ preserves !insideSlayers ==> acc(s.Mem(ubuf), def.ReadL50)
 // @ ensures   insideSlayers  ==> res == s.AddrHdrLenSpecInternal()
 // @ ensures   !insideSlayers ==> res == s.AddrHdrLenSpec(ubuf)
 // @ ensures   0 <= res
@@ -803,13 +803,13 @@ func packAddr(hostAddr net.Addr /*@ , ghost wildcard bool @*/) (addrtyp AddrType
 func (s *SCION) AddrHdrLen( /*@ ghost ubuf []byte, ghost insideSlayers bool @*/ ) (res int) {
 	/*@
 	ghost if !insideSlayers {
-		unfold acc(s.Mem(ubuf), def.ReadL25)
-		defer fold acc(s.Mem(ubuf), def.ReadL25)
-		unfold acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL25)
-		defer fold acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL25)
+		unfold acc(s.Mem(ubuf), def.ReadL51)
+		defer fold acc(s.Mem(ubuf), def.ReadL51)
+		unfold acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL51)
+		defer fold acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL51)
 		assert s.AddrHdrLenSpec(ubuf) == (
-			unfolding acc(s.Mem(ubuf), def.ReadL25) in
-			unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL25) in
+			unfolding acc(s.Mem(ubuf), def.ReadL52) in
+			unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL52) in
 			2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length())
 		assert s.AddrHdrLenSpec(ubuf) ==
 			2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length()

--- a/pkg/slayers/scion.go
+++ b/pkg/slayers/scion.go
@@ -807,6 +807,12 @@ func (s *SCION) AddrHdrLen( /*@ ghost ubuf []byte, ghost insideSlayers bool @*/ 
 		defer fold acc(s.Mem(ubuf), def.ReadL20/2)
 		unfold acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL20/2)
 		defer fold acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL20/2)
+		assert s.AddrHdrLenSpec(ubuf) == (
+			unfolding acc(s.Mem(ubuf), _) in
+			unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), _) in
+			2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length())
+		assert s.AddrHdrLenSpec(ubuf) ==
+			2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length()
 	}
 	@*/
 	return 2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length()

--- a/pkg/slayers/scion.go
+++ b/pkg/slayers/scion.go
@@ -803,6 +803,10 @@ func packAddr(hostAddr net.Addr /*@ , ghost wildcard bool @*/) (addrtyp AddrType
 func (s *SCION) AddrHdrLen( /*@ ghost ubuf []byte, ghost insideSlayers bool @*/ ) (res int) {
 	/*@
 	ghost if !insideSlayers {
+		assert s.AddrHdrLenSpec(ubuf) == (
+			unfolding acc(s.Mem(ubuf), _) in
+			unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), _) in
+			2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length())
 		unfold acc(s.Mem(ubuf), def.ReadL20/2)
 		defer fold acc(s.Mem(ubuf), def.ReadL20/2)
 		unfold acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL20/2)

--- a/pkg/slayers/scion_spec.gobra
+++ b/pkg/slayers/scion_spec.gobra
@@ -139,6 +139,8 @@ pred (s *SCION) NonInitMem() {
 	PathPoolMem(s.pathPool, s.pathPoolRaw)
 }
 
+// TODO: simplify the body of the predicate when let expressions
+//       support predicates
 pred (s *SCION) Mem(ubuf []byte) {
 	acc(&s.Version) &&
 	acc(&s.TrafficClass) &&
@@ -151,13 +153,13 @@ pred (s *SCION) Mem(ubuf []byte) {
 	acc(&s.SrcAddrType, def.HalfPerm) && s.SrcAddrType.Has3Bits() &&
 	// len of ubuf:
 	0 <= s.HdrLen &&
-	0 <= CmnHdrLen + s.AddrHdrLen(nil, true) &&
+	0 <= CmnHdrLen + s.AddrHdrLenSpecInternal() &&
 	s.HdrLen * LineLen <= len(ubuf) &&
-	CmnHdrLen + s.AddrHdrLen(nil, true) <= s.HdrLen * LineLen &&
+	CmnHdrLen + s.AddrHdrLenSpecInternal() <= s.HdrLen * LineLen &&
 	// end of len of ubuf
 	acc(&s.Path) &&
 	s.Path != nil &&
-	s.Path.Mem(ubuf[CmnHdrLen+s.AddrHdrLen(nil, true) : s.HdrLen*LineLen]) &&
+	s.Path.Mem(ubuf[CmnHdrLen+s.AddrHdrLenSpecInternal() : s.HdrLen*LineLen]) &&
 	acc(&s.BaseLayer) &&
 	// base layer fields:
 	s.Contents === ubuf[:s.HdrLen*LineLen] &&
@@ -175,18 +177,19 @@ pred (s *SCION) Mem(ubuf []byte) {
 	// end of path pool
 	// helpful facts for other methods:
 	// - for router::updateScionLayer:
-	(typeOf(s.Path) == type[*onehop.Path] ==> CmnHdrLen + s.AddrHdrLen(nil, true) + s.Path.Len(ubuf[CmnHdrLen+s.AddrHdrLen(nil, true) : s.HdrLen*LineLen]) <= len(ubuf))
+	(typeOf(s.Path) == type[*onehop.Path] ==> CmnHdrLen + s.AddrHdrLenSpecInternal() + s.Path.Len(ubuf[CmnHdrLen+s.AddrHdrLenSpecInternal() : s.HdrLen*LineLen]) <= len(ubuf))
 }
 
+// TODO: simplify the body of the predicate when let expressions
+//       support predicates
 pred (s *SCION) HeaderMem(ubuf []byte) {
 	acc(&s.DstIA) &&
 	acc(&s.SrcIA) &&
 	acc(&s.DstAddrType, def.HalfPerm) && s.DstAddrType.Has3Bits() &&
 	acc(&s.SrcAddrType, def.HalfPerm) && s.SrcAddrType.Has3Bits() &&
-	s.addrHdrLenAbstractionLeak() <= len(ubuf) &&
+	s.AddrHdrLenSpecInternal() <= len(ubuf) &&
 	// helper facts to deal with incompletnesses when establising the bounds of s.RawDstAddr and s.RawSrcAddr
-	s.AddrHdrLen(nil, true) == s.addrHdrLenAbstractionLeak() &&
-	s.AddrHdrLen(nil, true) <= len(ubuf) &&
+	s.AddrHdrLenSpecInternal() <= len(ubuf) &&
 	0 < s.DstAddrType.Length() && 0 < s.SrcAddrType.Length() &&
 	0 < 2*addr.IABytes &&
 	2*addr.IABytes < 2*addr.IABytes+s.DstAddrType.Length() &&
@@ -207,7 +210,7 @@ decreases
 func (s *SCION) DowngradePerm(ghost ub []byte) {
 	unfold s.Mem(ub)
 	unfold s.HeaderMem(ub[CmnHdrLen:])
-	s.Path.DowngradePerm(ub[CmnHdrLen+s.AddrHdrLen(nil, true) : s.HdrLen*LineLen])
+	s.Path.DowngradePerm(ub[CmnHdrLen+s.AddrHdrLenSpecInternal() : s.HdrLen*LineLen])
 	s.PathPoolMemExchange(s.PathType, s.Path)
 	fold s.NonInitMem()
 }
@@ -262,7 +265,8 @@ pure
 requires acc(s.Mem(ub), _)
 decreases
 func (s *SCION) UBPath(ub []byte) []byte {
-	return unfolding acc(s.Mem(ub), _) in ub[CmnHdrLen+s.AddrHdrLen(nil, true) : s.HdrLen*LineLen]
+	return unfolding acc(s.Mem(ub), _) in
+		ub[CmnHdrLen+s.AddrHdrLenSpecInternal() : s.HdrLen*LineLen]
 }
 
 ghost
@@ -270,7 +274,7 @@ pure
 requires acc(s.Mem(ub), _)
 decreases
 func (s *SCION) PathStartIdx(ub []byte) int {
-	return unfolding acc(s.Mem(ub), _) in CmnHdrLen+s.AddrHdrLen(nil, true)
+	return unfolding acc(s.Mem(ub), _) in CmnHdrLen+s.AddrHdrLenSpecInternal()
 }
 
 ghost
@@ -309,7 +313,7 @@ requires s.DstAddrType.Has3Bits() && s.SrcAddrType.Has3Bits()
 ensures  0 <= res
 decreases
 pure
-func (s *SCION) addrHdrLenAbstractionLeak() (res int) {
+func (s *SCION) AddrHdrLenSpecInternal() (res int) {
 	return 2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length()
 }
 
@@ -318,8 +322,10 @@ requires acc(s.Mem(ubuf), _)
 ensures  0 <= res
 decreases
 pure
-func (s *SCION) AddrHdrLenNoAbstractionLeak(ubuf []byte) (res int) {
-	return unfolding acc(s.Mem(ubuf), _) in (unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), _) in (2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length()))
+func (s *SCION) AddrHdrLenSpec(ubuf []byte) (res int) {
+	return unfolding acc(s.Mem(ubuf), _) in
+		(unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), _) in
+		(2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length()))
 }
 
 // Morally ghost
@@ -389,7 +395,9 @@ requires acc(&a.(*net.IPAddr).IP, _)
 requires forall i int :: { &a.(*net.IPAddr).IP[i] } 0 <= i && i < len(a.(*net.IPAddr).IP) ==> acc(&a.(*net.IPAddr).IP[i], _)
 requires len(a.(*net.IPAddr).IP) == net.IPv6len
 pure func isConvertibleToIPv4(a net.Addr) bool {
-	return net.isZeros(a.(*net.IPAddr).IP[0:10]) && a.(*net.IPAddr).IP[10] == 255 && a.(*net.IPAddr).IP[11] == 255
+	return net.isZeros(a.(*net.IPAddr).IP[0:10]) &&
+		a.(*net.IPAddr).IP[10] == 255 &&
+		a.(*net.IPAddr).IP[11] == 255
 }
 
 ghost
@@ -433,5 +441,8 @@ requires acc(s.Mem(ub), _)
 requires s.HasOneHopPath(ub)
 ensures  b
 pure func (s *SCION) InferSizeOHP(ghost ub []byte) (b bool) {
-	return unfolding acc(s.Mem(ub), _) in CmnHdrLen + s.AddrHdrLen(nil, true) + s.Path.Len(ub[CmnHdrLen+s.AddrHdrLen(nil, true) : s.HdrLen*LineLen]) <= len(ub)
+	return unfolding acc(s.Mem(ub), _) in
+		let pathSlice := ub[CmnHdrLen+s.AddrHdrLenSpecInternal() : s.HdrLen*LineLen] in
+		let pathLen := s.Path.Len(pathSlice) in
+		CmnHdrLen + s.AddrHdrLenSpecInternal() + pathLen <= len(ub)
 }

--- a/pkg/slayers/scion_spec.gobra
+++ b/pkg/slayers/scion_spec.gobra
@@ -318,13 +318,13 @@ func (s *SCION) AddrHdrLenSpecInternal() (res int) {
 }
 
 ghost
-requires acc(s.Mem(ubuf), def.ReadL30)
+requires acc(s.Mem(ubuf), def.ReadL55)
 ensures  0 <= res
 decreases
 pure
 func (s *SCION) AddrHdrLenSpec(ubuf []byte) (res int) {
-	return unfolding acc(s.Mem(ubuf), def.ReadL30) in
-		unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL30) in
+	return unfolding acc(s.Mem(ubuf), def.ReadL55) in
+		unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL55) in
 		2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length()
 }
 
@@ -394,6 +394,7 @@ requires typeOf(a) == *net.IPAddr
 requires acc(&a.(*net.IPAddr).IP, _)
 requires forall i int :: { &a.(*net.IPAddr).IP[i] } 0 <= i && i < len(a.(*net.IPAddr).IP) ==> acc(&a.(*net.IPAddr).IP[i], _)
 requires len(a.(*net.IPAddr).IP) == net.IPv6len
+decreases
 pure func isConvertibleToIPv4(a net.Addr) bool {
 	return net.isZeros(a.(*net.IPAddr).IP[0:10]) &&
 		a.(*net.IPAddr).IP[10] == 255 &&
@@ -403,6 +404,7 @@ pure func isConvertibleToIPv4(a net.Addr) bool {
 ghost
 requires typeOf(a) == *net.IPAddr
 requires acc(&a.(*net.IPAddr).IP, _)
+decreases
 pure func isIPv6(a net.Addr) bool {
 	return len(a.(*net.IPAddr).IP) == net.IPv6len
 }
@@ -410,16 +412,19 @@ pure func isIPv6(a net.Addr) bool {
 ghost
 requires typeOf(a) == *net.IPAddr
 requires acc(&a.(*net.IPAddr).IP, _)
+decreases
 pure func isIPv4(a net.Addr) bool {
 	return len(a.(*net.IPAddr).IP) == net.IPv4len
 }
 
 ghost
+decreases
 pure func isIP(a net.Addr) bool {
 	return typeOf(a) == *net.IPAddr
 }
 
 ghost
+decreases
 pure func isHostSVC(a net.Addr) bool {
 	return typeOf(a) == addr.HostSVC
 }
@@ -432,6 +437,7 @@ func EstablishPathPkgMem()
 
 ghost
 requires acc(s.Mem(ub), _)
+decreases
 pure func (s *SCION) HasOneHopPath(ghost ub []byte) bool {
 	return unfolding acc(s.Mem(ub), _) in typeOf(s.Path) == type[*onehop.Path]
 }
@@ -440,6 +446,7 @@ ghost
 requires acc(s.Mem(ub), _)
 requires s.HasOneHopPath(ub)
 ensures  b
+decreases
 pure func (s *SCION) InferSizeOHP(ghost ub []byte) (b bool) {
 	return unfolding acc(s.Mem(ub), _) in
 		let pathSlice := ub[CmnHdrLen+s.AddrHdrLenSpecInternal() : s.HdrLen*LineLen] in

--- a/pkg/slayers/scion_spec.gobra
+++ b/pkg/slayers/scion_spec.gobra
@@ -318,13 +318,13 @@ func (s *SCION) AddrHdrLenSpecInternal() (res int) {
 }
 
 ghost
-requires acc(s.Mem(ubuf), _)
+requires acc(s.Mem(ubuf), def.ReadL30)
 ensures  0 <= res
 decreases
 pure
 func (s *SCION) AddrHdrLenSpec(ubuf []byte) (res int) {
-	return unfolding acc(s.Mem(ubuf), _) in
-		unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), _) in
+	return unfolding acc(s.Mem(ubuf), def.ReadL30) in
+		unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), def.ReadL30) in
 		2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length()
 }
 

--- a/pkg/slayers/scion_spec.gobra
+++ b/pkg/slayers/scion_spec.gobra
@@ -324,8 +324,8 @@ decreases
 pure
 func (s *SCION) AddrHdrLenSpec(ubuf []byte) (res int) {
 	return unfolding acc(s.Mem(ubuf), _) in
-		(unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), _) in
-		(2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length()))
+		unfolding acc(s.HeaderMem(ubuf[CmnHdrLen:]), _) in
+		2*addr.IABytes + s.DstAddrType.Length() + s.SrcAddrType.Length()
 }
 
 // Morally ghost

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1690,12 +1690,12 @@ func (p *scionPacketProcessor) updateNonConsDirIngressSegID( /*@ ghost ub []byte
 // @ decreases
 func (p *scionPacketProcessor) currentInfoPointer( /*@ ghost ubScionL []byte @*/ ) uint16 {
 	// @ ghost ubPath := p.scionLayer.UBPath(ubScionL)
-	// @ unfold acc(p.scionLayer.Mem(ubScionL), def.ReadL20/2)
-	// @ defer  fold acc(p.scionLayer.Mem(ubScionL), def.ReadL20/2)
-	// @ unfold acc(p.scionLayer.Path.Mem(ubPath), def.ReadL20/2)
-	// @ defer  fold acc(p.scionLayer.Path.Mem(ubPath), def.ReadL20/2)
-	// @ unfold acc(p.scionLayer.Path.(*scion.Raw).Base.Mem(), def.ReadL20/2)
-	// @ defer  fold acc(p.scionLayer.Path.(*scion.Raw).Base.Mem(), def.ReadL20/2)
+	// @ unfold acc(p.scionLayer.Mem(ubScionL), def.ReadL21)
+	// @ defer  fold acc(p.scionLayer.Mem(ubScionL), def.ReadL21)
+	// @ unfold acc(p.scionLayer.Path.Mem(ubPath), def.ReadL21)
+	// @ defer  fold acc(p.scionLayer.Path.Mem(ubPath), def.ReadL21)
+	// @ unfold acc(p.scionLayer.Path.(*scion.Raw).Base.Mem(), def.ReadL21)
+	// @ defer  fold acc(p.scionLayer.Path.(*scion.Raw).Base.Mem(), def.ReadL21)
 	return uint16(slayers.CmnHdrLen + p.scionLayer.AddrHdrLen( /*@ ubScionL, false @*/ ) +
 		scion.MetaLen + path.InfoLen*int(p.path.PathMeta.CurrINF))
 }

--- a/verification/dependencies/net/ip.gobra
+++ b/verification/dependencies/net/ip.gobra
@@ -84,7 +84,8 @@ func (ip IP) To4(ghost wildcard bool) (res IP) {
 }
 
 pure
-preserves forall i int :: 0 <= i && i < len(s) ==> acc(&s[i], definitions.ReadL16)
+preserves forall i int :: { &s[i] } 0 <= i && i < len(s) ==> acc(&s[i], definitions.ReadL55)
+decreases
 func isZeros(s []byte) bool
 
 // To16 converts the IP address ip to a 16-byte representation.

--- a/verification/utils/definitions/definitions.gobra
+++ b/verification/utils/definitions/definitions.gobra
@@ -50,6 +50,31 @@ const (
 	ReadL28
 	ReadL29
 	ReadL30
+	ReadL31
+	ReadL32
+	ReadL33
+	ReadL34
+	ReadL35
+	ReadL36
+	ReadL37
+	ReadL38
+	ReadL39
+	ReadL40
+	ReadL41
+	ReadL42
+	ReadL43
+	ReadL44
+	ReadL45
+	ReadL46
+	ReadL47
+	ReadL48
+	ReadL49
+	ReadL50
+	ReadL51
+	ReadL52
+	ReadL53
+	ReadL54
+	ReadL55
 )
 
 // To be used as a precondition of functions and methods that can never be called
@@ -88,5 +113,5 @@ pure
 requires b
 decreases
 func Asserting(ghost b bool) bool {
-    return true
+	return true
 }

--- a/verification/utils/definitions/definitions.gobra
+++ b/verification/utils/definitions/definitions.gobra
@@ -40,6 +40,16 @@ const (
 	ReadL18
 	ReadL19
 	ReadL20
+	ReadL21
+	ReadL22
+	ReadL23
+	ReadL24
+	ReadL25
+	ReadL26
+	ReadL27
+	ReadL28
+	ReadL29
+	ReadL30
 )
 
 // To be used as a precondition of functions and methods that can never be called


### PR DESCRIPTION
This is currently blocked on an incompletness from silicon due to unnecessary usage of non-linear IA. There is also a verification error that I need to solve in the dataplane, but that is, for the most part, changing the permission amounts. I will address all of it after Marco solves the causes of the incompletness. Nonetheless, I guess the code can be reviewed already