### PR TITLE
IO-Spec fix

### DIFF
--- a/verification/io/io-spec.gobra
+++ b/verification/io/io-spec.gobra
@@ -54,8 +54,8 @@ pure func CBio_IN_bio3s_enter_T(t Place, v IO_val) Place
 ghost
 requires len(currseg.Future) > 0
 decreases
-pure func establishGuardTraversedseg(currseg IO_seg3) IO_seg3 {
-	return let uinfo := !currseg.ConsDir ?
+pure func establishGuardTraversedseg(currseg IO_seg3, direction bool) IO_seg3 {
+	return let uinfo := direction ?
 		upd_uinfo(currseg.UInfo, currseg.Future[0]) :
 		currseg.UInfo in
 		IO_seg3_ {
@@ -72,8 +72,8 @@ pure func establishGuardTraversedseg(currseg IO_seg3) IO_seg3 {
 ghost
 requires len(currseg.Future) > 0
 decreases
-pure func establishGuardTraversedsegInc(currseg IO_seg3) IO_seg3 {
-	return let uinfo := !currseg.ConsDir ?
+pure func establishGuardTraversedsegInc(currseg IO_seg3, direction bool) IO_seg3 {
+	return let uinfo := direction ?
 		upd_uinfo(currseg.UInfo, currseg.Future[0]) :
 		currseg.UInfo in
 		IO_seg3_ {
@@ -98,12 +98,7 @@ pure func (dp DataPlaneSpec) dp3s_iospec_bio3s_enter_guard(s IO_dp3s_state_local
 		len(v.IO_Internal_val1_1.CurrSeg.Future) > 0 &&
 		let currseg := v.IO_Internal_val1_1.CurrSeg in
 		let hf1, fut := currseg.Future[0], currseg.Future[1:] in
-		let traversedseg := match v.IO_Internal_val1_4{
-			case none[IO_ifs]: 
-				establishGuardTraversedseg(currseg)
-			default: 
-				establishGuardTraversedsegInc(currseg)
-		} in
+		let traversedseg := establishGuardTraversedseg(currseg, !currseg.ConsDir) in
 		dp.dp2_enter_guard(
 			v.IO_Internal_val1_1,
 			currseg,
@@ -157,12 +152,13 @@ pure func (dp DataPlaneSpec) dp3s_iospec_bio3s_xover_up2down_guard(s IO_dp3s_sta
 				false
 			default: 
 				let nextseg := get(v.IO_Internal_val1_1.LeftSeg) in
-				(nextseg.ConsDir &&
+				(!currseg.ConsDir &&
+				nextseg.ConsDir &&
 				len(nextseg.Future) > 0 &&
 				len(currseg.Future) > 0 &&
 				len(v.IO_Internal_val1_3.CurrSeg.Future) > 0 &&
 				let hf1, hf2 := currseg.Future[0], nextseg.Future[0] in
-				let traversedseg := establishGuardTraversedsegInc(currseg) in
+				let traversedseg := establishGuardTraversedsegInc(currseg, !currseg.ConsDir) in
 				(dp.xover_up2down2_link_type(dp.Asid(), hf1, hf2) &&
 					dp.dp3s_xover_common(
 						s,
@@ -218,7 +214,7 @@ pure func (dp DataPlaneSpec) dp3s_iospec_bio3s_xover_core_guard(s IO_dp3s_state_
 				len(currseg.Future) > 0 &&
 				len(v.IO_Internal_val1_3.CurrSeg.Future) > 0 &&
 				let hf1, hf2 := currseg.Future[0], nextseg.Future[0] in
-				let traversedseg := establishGuardTraversedsegInc(currseg) in
+				let traversedseg := establishGuardTraversedsegInc(currseg, !currseg.ConsDir) in
 				(dp.xover_core2_link_type(hf1, hf2, dp.Asid(), currseg.ConsDir) &&
 					dp.dp3s_xover_common(
 						s,


### PR DESCRIPTION
- Added missing clause in the `up2down` guard.
- Fixed `traversedseg` in the `enter` guard.
- Improved convenience of helper functions `establishGuardTraversedseg()` and `establishGuardTraversedsegInc()`.