### PR TITLE
Make method `addEndhostPort` not trusted

### DIFF
--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -3147,9 +3147,6 @@ func (d *DataPlane) resolveLocalDst(s *slayers.SCION /*@, ghost ub []byte @*/) (
 	}
 }
 
-// (VerifiedSCION) marked as trusted due to an incompletness in silicon,
-// where it is failing to prove the body of a predicate right after unfolding it.
-// @ trusted
 // @ requires acc(dst.Mem(), R15)
 // @ ensures  res != nil && acc(res.Mem(), R15)
 // @ ensures  acc(res.Mem(), R15) --* acc(dst.Mem(), R15)
@@ -3166,8 +3163,6 @@ func addEndhostPort(dst *net.IPAddr) (res *net.UDPAddr) {
 	// @ 	assert dst.IP === tmp.IP
 	// @ 	unfold acc(tmp.Mem(), R15)
 	// @ 	unfold acc(sl.AbsSlice_Bytes(tmp.IP, 0, len(tmp.IP)), R15)
-	// (VerifiedSCION) this is the failling assertion;
-	//                 TODO: report it!
 	// @ 	assert forall i int :: { &tmp.IP[i] } 0 <= i && i < len(tmp.IP) ==> acc(&tmp.IP[i], R15)
 	// @ 	assert forall i int :: { &dst.IP[i] } 0 <= i && i < len(dst.IP) ==> acc(&dst.IP[i], R15)
 	// @ 	fold acc(dst.Mem(), R15)


### PR DESCRIPTION
Due to an incompleteness in the packaging algorithm of Silicon, `addEndhostPort` could not be verified and was made `trusted`. This incompleteness was solved recently. This PR makes that function verified.