### PR TITLE
Add test that sets up a dataplane and runs it

### DIFF
--- a/router/dataplane_spec_test.gobra
+++ b/router/dataplane_spec_test.gobra
@@ -17,11 +17,17 @@
 package router
 
 import (
+	"context"
+	"hash"
 	"net"
 
 	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/slayers"
+	"github.com/scionproto/scion/pkg/scrypto"
 	"github.com/scionproto/scion/private/topology"
+
+	sl "github.com/scionproto/scion/verification/utils/slices"
+	io "verification/io"
 )
 
 func foldMem_test() {
@@ -73,3 +79,110 @@ func canModifyRunning(d *DataPlane) {
 	d.isRunningEq()
 	unfold d.Mem()
 }
+
+requires macFactory != nil                        &&
+	acc(key)                                      &&
+	acc(sl.AbsSlice_Bytes(*key, 0, len(*key)), _) &&
+	scrypto.ValidKeyForHash(*key)                 &&
+	macFactory implements MacFactorySpec{key}
+requires metrics != nil && metrics.Mem()
+requires ctx != nil && ctx.Mem()
+func testRun(
+	macFactory func() hash.Hash,
+	key *[]byte,
+	metrics *Metrics,
+	ctx context.Context,
+	place io.Place,
+	state io.IO_dp3s_state_local) (d *DataPlane) {
+	assume false // TODO: drop
+	// body similar to foldDataPlaneMem
+	d = &DataPlane{}
+
+	b1 := allocateBatchConn()
+	b2 := allocateBatchConn()
+	d.external = map[uint16]BatchConn{
+		uint16(1): b1,
+		uint16(2): b2,
+	}
+	fold accBatchConn(d.external)
+
+	d.linkTypes = make(map[uint16]topology.LinkType)
+	d.neighborIAs = make(map[uint16]addr.IA)
+
+	a1 := allocateUDPAddr()
+	d.internalNextHops = map[uint16]*net.UDPAddr{
+		uint16(3): a1,
+	}
+
+	localIA := 1000
+
+	d.internal = allocateBatchConn()
+	fold accAddr(d.internalNextHops)
+	d.svc = newServices()
+	d.macFactory = macFactory
+	d.key = key
+	d.localIA = addr.IA(localIA)
+	d.Metrics = metrics
+	d.bfdSessions = make(map[uint16]bfdSession)
+	fold accBfdSession(d.bfdSessions)
+	d.forwardingMetrics = make(map[uint16]forwardingMetrics)
+	fold accForwardingMetrics(d.forwardingMetrics)
+	fold d.Mem()
+	assert reveal d.PreWellConfigured()
+	fold MutexInvariant!< d !>()
+	// end of foldDataPlaneMem
+	assert !d.IsRunning()
+	assert d.InternalConnIsSet()
+	assert d.KeyIsSet()
+	assert d.SvcsAreSet()
+	assert d.MetricsAreSet()
+	d.mtx.SetInv(MutexInvariant!<d!>)
+	assert d.mtx.LockP()
+	assert d.mtx.LockInv() == MutexInvariant!<d!>;
+
+	// TODO: an ensures with the value that is returned is still
+	// missing here
+	ensures dp.Valid()
+	outline(
+	dp := io.DataPlaneSpec_{
+		linkTypes: dict[io.IO_ifs]io.IO_Link{
+			1: io.IO_ProvCust{},
+			2: io.IO_ProvCust{},
+			3: io.IO_ProvCust{},
+		},
+		neighborIAs: dict[io.IO_ifs]io.IO_as{
+			1: 1001,
+			2: 1002,
+			3: io.IO_as(localIA),
+		},
+		localIA: io.IO_as(localIA),
+		topology: io.TopologySpec_{
+			coreAS: set[io.IO_as]{io.IO_as(localIA)},
+			links:  dict[io.AsIfsPair]io.AsIfsPair {
+				io.AsIfsPair{io.IO_as(localIA), 1}: io.AsIfsPair{1001, 7},
+				io.AsIfsPair{io.IO_as(localIA), 2}: io.AsIfsPair{1002, 8},
+				io.AsIfsPair{1001, 7}: io.AsIfsPair{io.IO_as(localIA), 1},
+				io.AsIfsPair{1002, 8}: io.AsIfsPair{io.IO_as(localIA), 2}}}}
+	assert forall ifs IO_ifs :: {ifs in domain(dp.neighborIAs)} ifs in domain(dp.neighborIAs)  ==>
+		(AsIfsPair{dp.localIA, ifs} in domain(dp.topology.links) && dp.Lookup(AsIfsPair{dp.localIA, ifs}).asid == dp.neighborIAs[ifs])
+	assert forall ifs IO_ifs :: {ifs in domain(dp.neighborIAs)} AsIfsPair{dp.localIA, ifs} in domain(dp.topology.links) ==> ifs in domain(dp.neighborIAs)
+	assert forall pairs AsIfsPair :: {dp.Lookup(pairs)} pairs in domain(dp.topology.links) ==>
+			let next_pair := dp.Lookup(pairs) in
+			(next_pair in domain(dp.topology.links)) &&
+			dp.Lookup(next_pair) == pairs
+	assert reveal dp.Valid()
+	)
+	// @ requires d.DpAgreesWithSpec(dp)
+
+	// io-spec needs to be inhaled
+	inhale io.token(place)
+	inhale dp.dp3s_iospec_ordered(state, place)
+
+	d.Run(ctx, place, state, dp)
+}
+
+ensures b != nil && b.Mem()
+func allocateBatchConn() (b BatchConn)
+
+ensures u != nil && u.Mem()
+func allocateUDPAddr() (u *net.UDPAddr)

--- a/router/dataplane_spec_test.gobra
+++ b/router/dataplane_spec_test.gobra
@@ -163,10 +163,10 @@ func testRun(
 				io.AsIfsPair{io.IO_as(localIA), 2}: io.AsIfsPair{1002, 8},
 				io.AsIfsPair{1001, 7}: io.AsIfsPair{io.IO_as(localIA), 1},
 				io.AsIfsPair{1002, 8}: io.AsIfsPair{io.IO_as(localIA), 2}}}}
-	assert forall ifs IO_ifs :: {ifs in domain(dp.neighborIAs)} ifs in domain(dp.neighborIAs)  ==>
-		(AsIfsPair{dp.localIA, ifs} in domain(dp.topology.links) && dp.Lookup(AsIfsPair{dp.localIA, ifs}).asid == dp.neighborIAs[ifs])
-	assert forall ifs IO_ifs :: {ifs in domain(dp.neighborIAs)} AsIfsPair{dp.localIA, ifs} in domain(dp.topology.links) ==> ifs in domain(dp.neighborIAs)
-	assert forall pairs AsIfsPair :: {dp.Lookup(pairs)} pairs in domain(dp.topology.links) ==>
+	assert forall ifs io.IO_ifs :: {ifs in domain(dp.neighborIAs)} ifs in domain(dp.neighborIAs)  ==>
+		(io.AsIfsPair{dp.localIA, ifs} in domain(dp.topology.links) && dp.Lookup(io.AsIfsPair{dp.localIA, ifs}).asid == dp.neighborIAs[ifs])
+	assert forall ifs io.IO_ifs :: {ifs in domain(dp.neighborIAs)} io.AsIfsPair{dp.localIA, ifs} in domain(dp.topology.links) ==> ifs in domain(dp.neighborIAs)
+	assert forall pairs io.AsIfsPair :: {dp.Lookup(pairs)} pairs in domain(dp.topology.links) ==>
 			let next_pair := dp.Lookup(pairs) in
 			(next_pair in domain(dp.topology.links)) &&
 			dp.Lookup(next_pair) == pairs

--- a/router/dataplane_spec_test.gobra
+++ b/router/dataplane_spec_test.gobra
@@ -114,14 +114,12 @@ func testRun(
 		uint16(3): a1,
 	}
 
-	localIA := 1000
-
 	d.internal = allocateBatchConn()
 	fold accAddr(d.internalNextHops)
 	d.svc = newServices()
 	d.macFactory = macFactory
 	d.key = key
-	d.localIA = addr.IA(localIA)
+	d.localIA = 1000
 	d.Metrics = metrics
 	d.bfdSessions = make(map[uint16]bfdSession)
 	fold accBfdSession(d.bfdSessions)
@@ -143,7 +141,33 @@ func testRun(
 	// TODO: an ensures with the value that is returned is still
 	// missing here
 	ensures dp.Valid()
+	ensures dp === io.DataPlaneSpec_{
+		linkTypes: dict[io.IO_ifs]io.IO_Link{
+			1: io.IO_ProvCust{},
+			2: io.IO_ProvCust{},
+			3: io.IO_ProvCust{},
+		},
+		neighborIAs: dict[io.IO_ifs]io.IO_as{
+			1: 1001,
+			2: 1002,
+			3: 1000,
+		},
+		localIA: 1000,
+		topology: io.TopologySpec_{
+			coreAS: set[io.IO_as]{1000},
+			links:  dict[io.AsIfsPair]io.AsIfsPair {
+				io.AsIfsPair{1000, 1}: io.AsIfsPair{1001, 7},
+				io.AsIfsPair{1000, 2}: io.AsIfsPair{1002, 8},
+				io.AsIfsPair{1000, 3}: io.AsIfsPair{1000, 3},
+				io.AsIfsPair{1001, 7}: io.AsIfsPair{1000, 1},
+				io.AsIfsPair{1002, 8}: io.AsIfsPair{1000, 2}}}}
 	outline(
+	pair1 := io.AsIfsPair{1000, 1}
+	pair2 := io.AsIfsPair{1000, 2}
+	pair3 := io.AsIfsPair{1000, 3}
+	pair4 := io.AsIfsPair{1001, 7}
+	pair5 := io.AsIfsPair{1002, 8}
+
 	dp := io.DataPlaneSpec_{
 		linkTypes: dict[io.IO_ifs]io.IO_Link{
 			1: io.IO_ProvCust{},
@@ -153,23 +177,34 @@ func testRun(
 		neighborIAs: dict[io.IO_ifs]io.IO_as{
 			1: 1001,
 			2: 1002,
-			3: io.IO_as(localIA),
+			3: 1000,
 		},
-		localIA: io.IO_as(localIA),
+		localIA: 1000,
 		topology: io.TopologySpec_{
-			coreAS: set[io.IO_as]{io.IO_as(localIA)},
+			coreAS: set[io.IO_as]{1000},
 			links:  dict[io.AsIfsPair]io.AsIfsPair {
-				io.AsIfsPair{io.IO_as(localIA), 1}: io.AsIfsPair{1001, 7},
-				io.AsIfsPair{io.IO_as(localIA), 2}: io.AsIfsPair{1002, 8},
-				io.AsIfsPair{1001, 7}: io.AsIfsPair{io.IO_as(localIA), 1},
-				io.AsIfsPair{1002, 8}: io.AsIfsPair{io.IO_as(localIA), 2}}}}
-	assert forall ifs io.IO_ifs :: {ifs in domain(dp.neighborIAs)} ifs in domain(dp.neighborIAs)  ==>
-		(io.AsIfsPair{dp.localIA, ifs} in domain(dp.topology.links) && dp.Lookup(io.AsIfsPair{dp.localIA, ifs}).asid == dp.neighborIAs[ifs])
-	assert forall ifs io.IO_ifs :: {ifs in domain(dp.neighborIAs)} io.AsIfsPair{dp.localIA, ifs} in domain(dp.topology.links) ==> ifs in domain(dp.neighborIAs)
-	assert forall pairs io.AsIfsPair :: {dp.Lookup(pairs)} pairs in domain(dp.topology.links) ==>
-			let next_pair := dp.Lookup(pairs) in
+				pair1: pair4,
+				pair2: pair5,
+				pair3: pair3,
+				pair4: pair1,
+				pair5: pair2}}}
+
+	assert dp.Lookup(dp.Lookup(pair1)) == pair1
+	assert dp.Lookup(dp.Lookup(pair2)) == pair2
+	assert dp.Lookup(dp.Lookup(pair3)) == pair3
+	assert dp.Lookup(dp.Lookup(pair4)) == pair4
+	assert dp.Lookup(dp.Lookup(pair5)) == pair5
+
+	assert forall ifs io.IO_ifs :: {ifs in domain(dp.neighborIAs)} ifs in domain(dp.neighborIAs) ==>
+		io.AsIfsPair{dp.localIA, ifs} in domain(dp.topology.links)
+	assert forall ifs io.IO_ifs :: {ifs in domain(dp.neighborIAs)} ifs in domain(dp.neighborIAs) ==>
+		dp.Lookup(io.AsIfsPair{dp.localIA, ifs}).asid == dp.neighborIAs[ifs]
+	assert forall ifs io.IO_ifs :: {ifs in domain(dp.neighborIAs)} io.AsIfsPair{dp.localIA, ifs} in domain(dp.topology.links) ==>
+		ifs in domain(dp.neighborIAs)
+	assert forall pair io.AsIfsPair :: {dp.Lookup(pair)} pair in domain(dp.topology.links) ==>
+			let next_pair := dp.Lookup(pair) in
 			(next_pair in domain(dp.topology.links)) &&
-			dp.Lookup(next_pair) == pairs
+			dp.Lookup(next_pair) == pair
 	assert reveal dp.Valid()
 	)
 	// @ requires d.DpAgreesWithSpec(dp)

--- a/router/dataplane_spec_test.gobra
+++ b/router/dataplane_spec_test.gobra
@@ -94,7 +94,6 @@ func testRun(
 	ctx context.Context,
 	place io.Place,
 	state io.IO_dp3s_state_local) (d *DataPlane) {
-	assume false // TODO: drop
 	// body similar to foldDataPlaneMem
 	d = &DataPlane{}
 
@@ -125,21 +124,7 @@ func testRun(
 	fold accBfdSession(d.bfdSessions)
 	d.forwardingMetrics = make(map[uint16]forwardingMetrics)
 	fold accForwardingMetrics(d.forwardingMetrics)
-	fold d.Mem()
-	assert reveal d.PreWellConfigured()
-	fold MutexInvariant!< d !>()
-	// end of foldDataPlaneMem
-	assert !d.IsRunning()
-	assert d.InternalConnIsSet()
-	assert d.KeyIsSet()
-	assert d.SvcsAreSet()
-	assert d.MetricsAreSet()
-	d.mtx.SetInv(MutexInvariant!<d!>)
-	assert d.mtx.LockP()
-	assert d.mtx.LockInv() == MutexInvariant!<d!>;
 
-	// TODO: an ensures with the value that is returned is still
-	// missing here
 	ensures dp.Valid()
 	ensures dp === io.DataPlaneSpec_{
 		linkTypes: dict[io.IO_ifs]io.IO_Link{
@@ -207,7 +192,26 @@ func testRun(
 			dp.Lookup(next_pair) == pair
 	assert reveal dp.Valid()
 	)
-	// @ requires d.DpAgreesWithSpec(dp)
+
+	assert dp.Asid() == 1000
+	assert d.localIA == 1000
+	assert d.dpSpecWellConfiguredLocalIA(dp)
+	assert d.dpSpecWellConfiguredNeighborIAs(dp)
+	assert d.dpSpecWellConfiguredLinkTypes(dp)
+
+	fold d.Mem()
+	assert reveal d.DpAgreesWithSpec(dp)
+	assert reveal d.PreWellConfigured()
+	fold MutexInvariant!< d !>()
+	// end of foldDataPlaneMem
+	assert !d.IsRunning()
+	assert d.InternalConnIsSet()
+	assert d.KeyIsSet()
+	assert d.SvcsAreSet()
+	assert d.MetricsAreSet()
+	d.mtx.SetInv(MutexInvariant!<d!>)
+	assert d.mtx.LockP()
+	assert d.mtx.LockInv() == MutexInvariant!<d!>;
 
 	// io-spec needs to be inhaled
 	inhale io.token(place)

--- a/router/io-spec.gobra
+++ b/router/io-spec.gobra
@@ -538,10 +538,10 @@ pure func uInfo(hopfields seq[io.IO_HF], currHFIdx int, consDir bool) set[io.IO_
 	return currHFIdx == len(hopfields) ?
 		hvfSet(hopfields[currHFIdx-1]) :
 		(currHFIdx == 0 ?
+			hvfSet(hopfields[currHFIdx]) :
+			(consDir ?
 				hvfSet(hopfields[currHFIdx]) :
-				(consDir ?
-						hvfSet(hopfields[currHFIdx]) :
-						hvfSet(hopfields[currHFIdx-1])))
+				hvfSet(hopfields[currHFIdx-1])))
 }
 
 ghost
@@ -577,7 +577,7 @@ requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
 ensures val.isIO_val_Unsupported
 ensures val.IO_val_Unsupported_1 == ifsToIO_ifs(ingressID)
 decreases
-pure func absIO_val_Unsupported(raw []byte, ingressID uint16) (val io.IO_val){
+pure func absIO_val_Unsupported(raw []byte, ingressID uint16) (val io.IO_val) {
 	return io.IO_val(io.IO_val_Unsupported{
 		ifsToIO_ifs(ingressID),
 		io.Unit(io.Unit_{}),
@@ -598,7 +598,7 @@ pure func absIO_val(dp io.DataPlaneSpec, raw []byte, ingressID uint16) (val io.I
 ghost
 requires acc(&d.localIA, _)
 decreases
-pure func (d *DataPlane) dpSpecWellConfiguredLocalIA(dp io.DataPlaneSpec) bool{
+pure func (d *DataPlane) dpSpecWellConfiguredLocalIA(dp io.DataPlaneSpec) bool {
 	return io.IO_as(d.localIA) == dp.Asid()
 }
 

--- a/verification/io/dataplane_abstract.gobra
+++ b/verification/io/dataplane_abstract.gobra
@@ -33,7 +33,7 @@ type DataPlaneSpec adt {
 type TopologySpec adt {
 	TopologySpec_{
 		coreAS		set[IO_as]
-		links	 	dict[AsIfsPair]AsIfsPair
+		links		dict[AsIfsPair]AsIfsPair
 	}
 }
 
@@ -46,15 +46,15 @@ ghost
 opaque
 decreases
 pure func (dp DataPlaneSpec) Valid() bool {
-	return (forall ifs IO_ifs :: {ifs in domain(dp.neighborIAs)} ifs in domain(dp.neighborIAs)  ==> 
-			(AsIfsPair{dp.localIA, ifs} in domain(dp.topology.links) && 
+	return (forall ifs IO_ifs :: {ifs in domain(dp.neighborIAs)} ifs in domain(dp.neighborIAs)  ==>
+			(AsIfsPair{dp.localIA, ifs} in domain(dp.topology.links) &&
 			dp.Lookup(AsIfsPair{dp.localIA, ifs}).asid == dp.neighborIAs[ifs])) &&
 		(forall ifs IO_ifs :: {ifs in domain(dp.neighborIAs)} AsIfsPair{dp.localIA, ifs} in domain(dp.topology.links) ==>
 			ifs in domain(dp.neighborIAs)) &&
-		(forall pairs AsIfsPair :: {dp.Lookup(pairs)} pairs in domain(dp.topology.links) ==>  
+		(forall pairs AsIfsPair :: {dp.Lookup(pairs)} pairs in domain(dp.topology.links) ==>
 			let next_pair := dp.Lookup(pairs) in
 			(next_pair in domain(dp.topology.links)) &&
-			dp.Lookup(next_pair) == pairs) 
+			dp.Lookup(next_pair) == pairs)
 			// && domain(dp.linkTypes) == domain(dp.neighborIAs)
 }
 


### PR DESCRIPTION
This PR contains a test that allocates a `DataPlane`, sets it up, and then calls the `Run` method. In the interest of time, I did not add a specification to the setters. Instead, I performed the set-up by assigning to the (private) fields directly, as my goal was to have a proof that we can establish the preconditions of `Run` right after allocation.