### PR TITLE
Updated IO-Spec-Function to Correlate Bytes with Terms

### DIFF
--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1688,9 +1688,9 @@ func (p *scionPacketProcessor) processIntraBFD(data []byte) (res error) {
 // @ requires acc(ioLock.LockP(), _) && ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>;
 // @ requires let absPkt := absIO_val(dp, p.rawPkt, p.ingressID) in
 // @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.ingressID), absPkt.IO_val_Pkt2_2)
-// @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&
+// @ ensures reserr == nil && newAbsPkt.isIO_val_Pkt2 ==>
 // @	ElemWitness(ioSharedArg.OBufY, newAbsPkt.IO_val_Pkt2_1, newAbsPkt.IO_val_Pkt2_2)
-// @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&
+// @ ensures reserr == nil && newAbsPkt.isIO_val_Pkt2 ==>
 // @	newAbsPkt == absIO_val(dp, respr.OutPkt, respr.EgressID)
 func (p *scionPacketProcessor) processSCION( /*@ ghost ub []byte, ghost llIsNil bool, ghost startLL int, ghost endLL int, ghost ioLock *sync.Mutex, ghost ioSharedArg SharedArg, ghost dp io.DataPlaneSpec @*/ ) (respr processResult, reserr error /*@ , addrAliasesPkt bool, ghost newAbsPkt io.IO_val  @*/) {
 
@@ -2785,9 +2785,9 @@ func (p *scionPacketProcessor) validatePktLen( /*@ ghost ubScionL []byte @*/ ) (
 // @ requires acc(ioLock.LockP(), _) && ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>;
 // @ requires let absPkt := absIO_val(dp, ub, p.ingressID) in
 // @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.ingressID), absPkt.IO_val_Pkt2_2)
-// @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&
+// @ ensures reserr == nil && newAbsPkt.isIO_val_Pkt2 ==>
 // @	ElemWitness(ioSharedArg.OBufY, newAbsPkt.IO_val_Pkt2_1, newAbsPkt.IO_val_Pkt2_2)
-// @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&
+// @ ensures reserr == nil && newAbsPkt.isIO_val_Pkt2 ==>
 // @	newAbsPkt == absIO_val(dp, respr.OutPkt, respr.EgressID)
 func (p *scionPacketProcessor) process( /*@ ghost ub []byte, ghost llIsNil bool, ghost startLL int, ghost endLL int, ghost ioLock *sync.Mutex, ghost ioSharedArg SharedArg, ghost dp io.DataPlaneSpec @*/ ) (respr processResult, reserr error /*@, addrAliasesPkt bool, ghost newAbsPkt io.IO_val @*/) {
 	if r, err := p.parsePath( /*@ ub @*/ ); err != nil {

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1659,7 +1659,7 @@ func (p *scionPacketProcessor) processIntraBFD(data []byte) (res error) {
 // @ 	acc(p.lastLayer.Mem(nil), R10)
 // @ preserves (p.lastLayer !== &p.scionLayer && !llIsNil) ==>
 // @ 	acc(p.lastLayer.Mem(ub[startLL:endLL]), R10)
-// @ preserves acc(&p.ingressID, R20)
+// @ requires  acc(&p.ingressID, R20)
 // @ preserves acc(&p.infoField)
 // @ preserves acc(&p.hopField)
 // @ preserves acc(&p.segmentChange)
@@ -1667,6 +1667,7 @@ func (p *scionPacketProcessor) processIntraBFD(data []byte) (res error) {
 // @ preserves acc(&p.macBuffers.scionInput, R10)
 // @ preserves sl.AbsSlice_Bytes(p.macBuffers.scionInput, 0, len(p.macBuffers.scionInput))
 // @ preserves acc(&p.cachedMac)
+// @ ensures   acc(&p.ingressID, R20)
 // @ ensures   acc(&p.d, R5)
 // @ ensures   acc(&p.path)
 // @ ensures   acc(&p.rawPkt, R1)
@@ -1685,10 +1686,8 @@ func (p *scionPacketProcessor) processIntraBFD(data []byte) (res error) {
 // @ requires p.d.DpAgreesWithSpec(dp)
 // @ requires dp.Valid()
 // @ requires acc(ioLock.LockP(), _) && ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>;
-// @ requires acc(&p.ingressID)
 // @ requires let absPkt := absIO_val(dp, p.rawPkt, p.ingressID) in
 // @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.ingressID), absPkt.IO_val_Pkt2_2)
-// @ ensures acc(&p.ingressID)
 // @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&
 // @	ElemWitness(ioSharedArg.OBufY, newAbsPkt.IO_val_Pkt2_1, newAbsPkt.IO_val_Pkt2_2)
 // @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1374,7 +1374,8 @@ func (p *scionPacketProcessor) reset() (err error) {
 // @ 	acc(d.Mem(), _) &&
 // @ 	d.WellConfigured()        &&
 // @ 	d.getValSvc() != nil      &&
-// @ 	d.getValForwardingMetrics() != nil
+// @ 	d.getValForwardingMetrics() != nil &&
+// @	d.DpAgreesWithSpec(dp)
 // @ ensures  p.sInit()
 // @ ensures  acc(p.sInitD().Mem(), _)
 // @ ensures  p.sInitD() == old(p.sInitD())
@@ -1683,6 +1684,7 @@ func (p *scionPacketProcessor) processIntraBFD(data []byte) (res error) {
 // @ 	sl.AbsSlice_Bytes(respr.OutPkt, 0, len(respr.OutPkt))
 // @ ensures   reserr != nil ==> reserr.ErrorMem()
 // contracts for IO-spec
+// @ requires p.d.DpAgreesWithSpec(dp)
 // @ requires dp.Valid()
 // @ requires acc(ioLock.LockP(), _) && ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>;
 // @ requires acc(&p.ingressID)
@@ -1706,7 +1708,7 @@ func (p *scionPacketProcessor) processSCION( /*@ ghost ub []byte, ghost llIsNil 
 		// @ fold p.d.validResult(processResult{}, false)
 		return processResult{}, malformedPath /*@ , false, io.IO_val_Unit{} @*/
 	}
-	return p.process( /*@ ub, llIsNil, startLL, endLL @*/ )
+	return p.process( /*@ ub, llIsNil, startLL, endLL , ioLock, ioSharedArg, dp @*/ )
 }
 
 // @ trusted
@@ -2750,6 +2752,7 @@ func (p *scionPacketProcessor) validatePktLen( /*@ ghost ubScionL []byte @*/ ) (
 // @ requires  p.scionLayer.Mem(ub)
 // @ requires  p.path == p.scionLayer.GetPath(ub)
 // @ requires  sl.AbsSlice_Bytes(ub, 0, len(ub))
+// @ requires acc(&p.ingressID, R20)
 // @ preserves acc(&p.srcAddr, R10) && acc(p.srcAddr.Mem(), _)
 // @ preserves acc(&p.lastLayer, R10)
 // @ preserves p.lastLayer != nil
@@ -2757,7 +2760,6 @@ func (p *scionPacketProcessor) validatePktLen( /*@ ghost ubScionL []byte @*/ ) (
 // @ 	acc(p.lastLayer.Mem(nil), R10)
 // @ preserves (p.lastLayer !== &p.scionLayer && !llIsNil) ==>
 // @ 	acc(p.lastLayer.Mem(ub[startLL:endLL]), R10)
-// @ preserves acc(&p.ingressID, R20)
 // @ preserves acc(&p.infoField)
 // @ preserves acc(&p.hopField)
 // @ preserves acc(&p.segmentChange)
@@ -2765,6 +2767,7 @@ func (p *scionPacketProcessor) validatePktLen( /*@ ghost ubScionL []byte @*/ ) (
 // @ preserves acc(&p.macBuffers.scionInput, R10)
 // @ preserves sl.AbsSlice_Bytes(p.macBuffers.scionInput, 0, len(p.macBuffers.scionInput))
 // @ preserves acc(&p.cachedMac)
+// @ ensures acc(&p.ingressID, R20)
 // @ ensures   acc(&p.d, R5)
 // @ ensures   acc(&p.path, R10)
 // @ ensures   acc(&p.rawPkt, R1)
@@ -2779,7 +2782,17 @@ func (p *scionPacketProcessor) validatePktLen( /*@ ghost ubScionL []byte @*/ ) (
 // @ ensures   reserr == nil ==> p.scionLayer.Mem(ub)
 // @ ensures   reserr != nil ==> p.scionLayer.NonInitMem()
 // @ ensures   reserr != nil ==> reserr.ErrorMem()
-func (p *scionPacketProcessor) process( /*@ ghost ub []byte, ghost llIsNil bool, ghost startLL int, ghost endLL int @*/ ) (respr processResult, reserr error /*@, addrAliasesPkt bool, ghost newAbsPkt io.IO_val @*/) {
+// contracts for IO-spec
+// @ requires p.d.DpAgreesWithSpec(dp)
+// @ requires dp.Valid()
+// @ requires acc(ioLock.LockP(), _) && ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>;
+// @ requires let absPkt := absIO_val(dp, ub, p.ingressID) in
+// @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.ingressID), absPkt.IO_val_Pkt2_2)
+// @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&
+// @	ElemWitness(ioSharedArg.OBufY, newAbsPkt.IO_val_Pkt2_1, newAbsPkt.IO_val_Pkt2_2)
+// @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&
+// @	newAbsPkt == absIO_val(dp, respr.OutPkt, respr.EgressID)
+func (p *scionPacketProcessor) process( /*@ ghost ub []byte, ghost llIsNil bool, ghost startLL int, ghost endLL int, ghost ioLock *sync.Mutex, ghost ioSharedArg SharedArg, ghost dp io.DataPlaneSpec @*/ ) (respr processResult, reserr error /*@, addrAliasesPkt bool, ghost newAbsPkt io.IO_val @*/) {
 	if r, err := p.parsePath( /*@ ub @*/ ); err != nil {
 		// @ p.scionLayer.DowngradePerm(ub)
 		return r, err /*@, false, io.IO_val_Unit{} @*/

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -2749,7 +2749,7 @@ func (p *scionPacketProcessor) validatePktLen( /*@ ghost ubScionL []byte @*/ ) (
 // @ requires  p.scionLayer.Mem(ub)
 // @ requires  p.path == p.scionLayer.GetPath(ub)
 // @ requires  sl.AbsSlice_Bytes(ub, 0, len(ub))
-// @ requires acc(&p.ingressID, R20)
+// @ requires   acc(&p.ingressID, R20)
 // @ preserves acc(&p.srcAddr, R10) && acc(p.srcAddr.Mem(), _)
 // @ preserves acc(&p.lastLayer, R10)
 // @ preserves p.lastLayer != nil
@@ -2764,7 +2764,7 @@ func (p *scionPacketProcessor) validatePktLen( /*@ ghost ubScionL []byte @*/ ) (
 // @ preserves acc(&p.macBuffers.scionInput, R10)
 // @ preserves sl.AbsSlice_Bytes(p.macBuffers.scionInput, 0, len(p.macBuffers.scionInput))
 // @ preserves acc(&p.cachedMac)
-// @ ensures acc(&p.ingressID, R20)
+// @ ensures   acc(&p.ingressID, R20)
 // @ ensures   acc(&p.d, R5)
 // @ ensures   acc(&p.path, R10)
 // @ ensures   acc(&p.rawPkt, R1)

--- a/router/io-spec.gobra
+++ b/router/io-spec.gobra
@@ -134,16 +134,16 @@ pure func asidsAfter(
 	asid io.IO_as) (res option[seq[io.IO_as]]) {
 	return  currHFIdx == segLen - 1 ? some(seq[io.IO_as]{asid}) :
 		let next_asid := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in asidFromIfs(dp, raw, numINF, currHFIdx, consDir, asid)) in
-			match next_asid{
-				case none[io.IO_as]:
-					none[seq[io.IO_as]]
-				default:
-					let next_asid_seq := asidsAfter(dp, raw, numINF, currHFIdx+1, segLen, consDir, get(next_asid)) in
-					match next_asid_seq{
-						case none[seq[io.IO_as]]:
-							none[seq[io.IO_as]]
-						default:
-							some(seq[io.IO_as]{asid} ++ get(next_asid_seq))
+		match next_asid{
+			case none[io.IO_as]:
+				none[seq[io.IO_as]]
+			default:
+				let next_asid_seq := asidsAfter(dp, raw, numINF, currHFIdx+1, segLen, consDir, get(next_asid)) in
+				match next_asid_seq{
+					case none[seq[io.IO_as]]:
+						none[seq[io.IO_as]]
+					default:
+						some(seq[io.IO_as]{asid} ++ get(next_asid_seq))
 				}
 		}
 }

--- a/router/io-spec.gobra
+++ b/router/io-spec.gobra
@@ -23,6 +23,7 @@ import (
 	"github.com/scionproto/scion/pkg/slayers/path"
 	"github.com/scionproto/scion/pkg/slayers/path/scion"
 	"github.com/scionproto/scion/private/topology"
+	. "github.com/scionproto/scion/verification/utils/definitions"
 )
 
 ghost
@@ -64,9 +65,8 @@ ghost
 requires 1 <= numINF
 requires 0 <= currHFIdx
 requires hopFieldOffset(numINF, currHFIdx) + path.HopLen <= len(raw)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
 requires dp.Valid()
-requires let idx := hopFieldOffset(numINF, currHFIdx) in
-	acc(&raw[idx+2], _) && acc(&raw[idx+3], _) && acc(&raw[idx+4], _) && acc(&raw[idx+5], _)
 decreases
 pure func asidFromIfs(
 	dp io.DataPlaneSpec,
@@ -76,6 +76,11 @@ pure func asidFromIfs(
 	consDir bool,
 	asid io.IO_as) (res option[io.IO_as]) {
 	return let idx := hopFieldOffset(numINF, currHFIdx) in
+		unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in 
+		let _ := Asserting(forall i int :: { &raw[idx+2+i] } { &raw[idx+2:idx+4][i] } 0 <= i && i < 2 ==> 
+			&raw[idx+2+i] == &raw[idx+2:idx+4][i]) in
+		let _ := Asserting(forall i int :: { &raw[idx+4+i] } { &raw[idx+4:idx+6][i] } 0 <= i && i < 2 ==> 
+			&raw[idx+4+i] == &raw[idx+4:idx+6][i]) in
 		let ifs := consDir ? binary.BigEndian.Uint16(raw[idx+4:idx+6]) : binary.BigEndian.Uint16(raw[idx+2:idx+4]) in
 		let asIfPair := io.AsIfsPair{asid, io.IO_ifs(ifs)} in
 		(asIfPair in domain(dp.GetLinks()) ?
@@ -100,7 +105,7 @@ pure func asidsBefore(
 	consDir bool,
 	asid io.IO_as) (res option[seq[io.IO_as]]) {
 	return currHFIdx == prevSegLen ? some(seq[io.IO_as]{asid}) :
-		let nextAsid := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in asidFromIfs(dp, raw, numINF, currHFIdx, !consDir, asid)) in
+		let nextAsid := asidFromIfs(dp, raw, numINF, currHFIdx, !consDir, asid) in
 		match nextAsid{
 			case none[io.IO_as]:
 				none[seq[io.IO_as]]
@@ -133,7 +138,7 @@ pure func asidsAfter(
 	consDir bool,
 	asid io.IO_as) (res option[seq[io.IO_as]]) {
 	return  currHFIdx == segLen - 1 ? some(seq[io.IO_as]{asid}) :
-		let nextAsid := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in asidFromIfs(dp, raw, numINF, currHFIdx, consDir, asid)) in
+		let nextAsid := asidFromIfs(dp, raw, numINF, currHFIdx, consDir, asid) in
 		match nextAsid{
 			case none[io.IO_as]:
 				none[seq[io.IO_as]]
@@ -247,11 +252,16 @@ pure func asidsForMidSeg(dp io.DataPlaneSpec, raw []byte, numINF int, currINFIdx
 ghost
 requires idx + path.HopLen <= len(raw)
 requires 0 <= idx
-requires acc(&raw[idx+2], _) && acc(&raw[idx+3], _) && acc(&raw[idx+4], _) && acc(&raw[idx+5], _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
 ensures  len(res.HVF.MsgTerm_Hash_.MsgTerm_MPair_2.MsgTerm_L_) > 0
 decreases
 pure func hopField(raw []byte, idx int, beta set[io.IO_msgterm], asid io.IO_as, ainfo io.IO_ainfo) (res io.IO_HF) {
-	return let inif2 := binary.BigEndian.Uint16(raw[idx+2:idx+4]) in
+	return unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in 
+		let _ := Asserting(forall i int :: { &raw[idx+2+i] } { &raw[idx+2:idx+4][i] } 0 <= i && i < 2 ==> 
+			&raw[idx+2+i] == &raw[idx+2:idx+4][i]) in
+		let _ := Asserting(forall i int :: { &raw[idx+4+i] } { &raw[idx+4:idx+6][i] } 0 <= i && i < 2 ==> 
+			&raw[idx+4+i] == &raw[idx+4:idx+6][i]) in
+		let inif2 := binary.BigEndian.Uint16(raw[idx+2:idx+4]) in
 		let egif2 := binary.BigEndian.Uint16(raw[idx+4:idx+6]) in
 		let op_inif2 := inif2 == 0 ? none[io.IO_ifs] : some(io.IO_ifs(inif2)) in
 		let op_egif2 := egif2 == 0 ? none[io.IO_ifs] : some(io.IO_ifs(egif2)) in
@@ -285,8 +295,7 @@ pure func hopFieldsConsDir(
 	asid seq[io.IO_as],
 	ainfo io.IO_ainfo) (res seq[io.IO_HF]) {
 	return currHFIdx == len(asid) ? seq[io.IO_HF]{} :
-		let hf := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in
-			hopField(raw, offset + path.HopLen * currHFIdx, beta, asid[currHFIdx], ainfo)) in
+		let hf := hopField(raw, offset + path.HopLen * currHFIdx, beta, asid[currHFIdx], ainfo) in
 		seq[io.IO_HF]{hf} ++ hopFieldsConsDir(raw, offset, currHFIdx + 1, (beta union set[io.IO_msgterm]{hf.HVF}), asid, ainfo)
 }
 
@@ -309,8 +318,7 @@ pure func hopFieldsNotConsDir(
 	asid seq[io.IO_as],
 	ainfo io.IO_ainfo) (res seq[io.IO_HF]) {
 	return currHFIdx == -1 ? seq[io.IO_HF]{} :
-		let hf := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in
-			hopField(raw, offset + path.HopLen * currHFIdx, beta, asid[currHFIdx], ainfo)) in
+		let hf := hopField(raw, offset + path.HopLen * currHFIdx, beta, asid[currHFIdx], ainfo) in
 		hopFieldsNotConsDir(raw, offset, currHFIdx - 1, (beta union set[io.IO_msgterm]{hf.HVF}), asid, ainfo) ++ seq[io.IO_HF]{hf}
 }
 

--- a/router/io-spec.gobra
+++ b/router/io-spec.gobra
@@ -17,13 +17,13 @@
 package router
 
 import (
-	sl "github.com/scionproto/scion/verification/utils/slices"
-	"github.com/scionproto/scion/verification/io"
-	"github.com/scionproto/scion/verification/dependencies/encoding/binary"
+	sl "verification/utils/slices"
+	"verification/io"
+	"verification/dependencies/encoding/binary"
 	"github.com/scionproto/scion/pkg/slayers/path"
 	"github.com/scionproto/scion/pkg/slayers/path/scion"
 	"github.com/scionproto/scion/private/topology"
-	. "github.com/scionproto/scion/verification/utils/definitions"
+	. "verification/utils/definitions"
 )
 
 ghost

--- a/router/io-spec.gobra
+++ b/router/io-spec.gobra
@@ -100,17 +100,17 @@ pure func asidsBefore(
 	consDir bool,
 	asid io.IO_as) (res option[seq[io.IO_as]]) {
 	return currHFIdx == prevSegLen ? some(seq[io.IO_as]{asid}) :
-		let next_asid := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in asidFromIfs(dp, raw, numINF, currHFIdx, !consDir, asid)) in
-		match next_asid{
+		let nextAsid := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in asidFromIfs(dp, raw, numINF, currHFIdx, !consDir, asid)) in
+		match nextAsid{
 			case none[io.IO_as]:
 				none[seq[io.IO_as]]
 			default:
-				let next_asid_seq := asidsBefore(dp, raw, numINF, currHFIdx-1, prevSegLen, consDir, get(next_asid)) in
-				match next_asid_seq{
+				let nextAsidSeq := asidsBefore(dp, raw, numINF, currHFIdx-1, prevSegLen, consDir, get(nextAsid)) in
+				match nextAsidSeq{
 					case none[seq[io.IO_as]]:
 						none[seq[io.IO_as]]
 					default:
-						some(get(next_asid_seq) ++ seq[io.IO_as]{asid})
+						some(get(nextAsidSeq) ++ seq[io.IO_as]{asid})
 				}
 		}
 }
@@ -133,17 +133,17 @@ pure func asidsAfter(
 	consDir bool,
 	asid io.IO_as) (res option[seq[io.IO_as]]) {
 	return  currHFIdx == segLen - 1 ? some(seq[io.IO_as]{asid}) :
-		let next_asid := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in asidFromIfs(dp, raw, numINF, currHFIdx, consDir, asid)) in
-		match next_asid{
+		let nextAsid := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in asidFromIfs(dp, raw, numINF, currHFIdx, consDir, asid)) in
+		match nextAsid{
 			case none[io.IO_as]:
 				none[seq[io.IO_as]]
 			default:
-				let next_asid_seq := asidsAfter(dp, raw, numINF, currHFIdx+1, segLen, consDir, get(next_asid)) in
-				match next_asid_seq{
+				let nextAsidSeq := asidsAfter(dp, raw, numINF, currHFIdx+1, segLen, consDir, get(nextAsid)) in
+				match nextAsidSeq{
 					case none[seq[io.IO_as]]:
 						none[seq[io.IO_as]]
 					default:
-						some(seq[io.IO_as]{asid} ++ get(next_asid_seq))
+						some(seq[io.IO_as]{asid} ++ get(nextAsidSeq))
 				}
 		}
 }

--- a/router/io-spec.gobra
+++ b/router/io-spec.gobra
@@ -59,7 +59,7 @@ pure func lengthOfPrevSeg(currHF int, seg1Len int, seg2Len int, seg3Len int) (re
 	return seg1Len > currHF ? 0 : ((seg1Len + seg2Len) > currHF ? seg1Len : seg1Len + seg2Len)
 }
 
-// returns the ASid of a hopfield
+// returns the ASid of the next hopfield
 ghost
 requires 1 <= numINF
 requires 0 <= currHFIdx
@@ -99,18 +99,18 @@ pure func asidsBefore(
 	prevSegLen int,
 	consDir bool,
 	asid io.IO_as) (res option[seq[io.IO_as]]) {
-	return let next_asid := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in asidFromIfs(dp, raw, numINF, currHFIdx, !consDir, asid)) in
+	return currHFIdx == prevSegLen ? some(seq[io.IO_as]{asid}) :
+		let next_asid := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in asidFromIfs(dp, raw, numINF, currHFIdx, !consDir, asid)) in
 		match next_asid{
 			case none[io.IO_as]:
 				none[seq[io.IO_as]]
 			default:
-				currHFIdx == prevSegLen ? some(seq[io.IO_as]{get(next_asid)}) :
 				let next_asid_seq := asidsBefore(dp, raw, numINF, currHFIdx-1, prevSegLen, consDir, get(next_asid)) in
 				match next_asid_seq{
 					case none[seq[io.IO_as]]:
 						none[seq[io.IO_as]]
 					default:
-						some(get(next_asid_seq) ++ seq[io.IO_as]{get(next_asid)})
+						some(get(next_asid_seq) ++ seq[io.IO_as]{asid})
 				}
 		}
 }
@@ -132,18 +132,18 @@ pure func asidsAfter(
 	segLen int,
 	consDir bool,
 	asid io.IO_as) (res option[seq[io.IO_as]]) {
-	return let next_asid := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in asidFromIfs(dp, raw, numINF, currHFIdx, consDir, asid)) in
-		match next_asid{
-			case none[io.IO_as]:
-				none[seq[io.IO_as]]
-			default:
-				currHFIdx == segLen - 1 ? some(seq[io.IO_as]{get(next_asid)}) :
-				let next_asid_seq := asidsAfter(dp, raw, numINF, currHFIdx+1, segLen, consDir, get(next_asid)) in
-				match next_asid_seq{
-					case none[seq[io.IO_as]]:
-						none[seq[io.IO_as]]
-					default:
-						some(seq[io.IO_as]{get(next_asid)} ++ get(next_asid_seq))
+	return  currHFIdx == segLen - 1 ? some(seq[io.IO_as]{asid}) :
+		let next_asid := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in asidFromIfs(dp, raw, numINF, currHFIdx, consDir, asid)) in
+			match next_asid{
+				case none[io.IO_as]:
+					none[seq[io.IO_as]]
+				default:
+					let next_asid_seq := asidsAfter(dp, raw, numINF, currHFIdx+1, segLen, consDir, get(next_asid)) in
+					match next_asid_seq{
+						case none[seq[io.IO_as]]:
+							none[seq[io.IO_as]]
+						default:
+							some(seq[io.IO_as]{asid} ++ get(next_asid_seq))
 				}
 		}
 }
@@ -274,6 +274,8 @@ requires  acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
 ensures   len(res) == len(asid) - currHFIdx
 ensures   forall k int :: {res[k]} 0 <= k && k < len(res) ==>
 	len(res[k].HVF.MsgTerm_Hash_.MsgTerm_MPair_2.MsgTerm_L_) > 0
+ensures   forall k int :: {res[k]} 0 <= k && k < len(res) ==>
+	res[k].extr_asid() == asid[k + currHFIdx]
 decreases len(asid) - currHFIdx
 pure func hopFieldsConsDir(
 	raw []byte,
@@ -296,6 +298,8 @@ requires  acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
 ensures   len(res) == currHFIdx + 1
 ensures   forall k int :: {res[k]} 0 <= k && k < len(res) ==>
 	len(res[k].HVF.MsgTerm_Hash_.MsgTerm_MPair_2.MsgTerm_L_) > 0
+ensures   forall k int :: {res[k]} 0 <= k && k < len(res) ==>
+	res[k].extr_asid() == asid[k]
 decreases currHFIdx + 1
 pure func hopFieldsNotConsDir(
 	raw []byte,
@@ -307,7 +311,7 @@ pure func hopFieldsNotConsDir(
 	return currHFIdx == -1 ? seq[io.IO_HF]{} :
 		let hf := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in
 			hopField(raw, offset + path.HopLen * currHFIdx, beta, asid[currHFIdx], ainfo)) in
-		hopFieldsNotConsDir(raw, offset, currHFIdx -1, (beta union set[io.IO_msgterm]{hf.HVF}), asid, ainfo) ++ seq[io.IO_HF]{hf}
+		hopFieldsNotConsDir(raw, offset, currHFIdx - 1, (beta union set[io.IO_msgterm]{hf.HVF}), asid, ainfo) ++ seq[io.IO_HF]{hf}
 }
 
 ghost


### PR DESCRIPTION
- Fixed mistake in Asid extraction function
- Added additional postconditions in `HopfieldsConsDir()` and `HopfieldsNotConsDir()`
- Added pre/postconditions for `process`
- Added `DpAgreesWithSpec()` to `processPkt()`, `processSCION()` and `process()`
