### PR TITLE
AbsPkt improvements

### DIFF
--- a/pkg/slayers/path/hopfield_spec.gobra
+++ b/pkg/slayers/path/hopfield_spec.gobra
@@ -16,32 +16,6 @@
 
 package path
 
-ghost const MetaLen = 4
-
 pred (h *HopField) Mem() {
 	acc(h) && h.ConsIngress >= 0 && h.ConsEgress >= 0
-}
-
-ghost 
-decreases
-pure func InfoFieldOffset(currINF int) int {
-	return MetaLen + InfoLen * currINF
-}
-
-ghost 
-requires 0 <= currINF
-requires InfoFieldOffset(currINF) < len(raw)
-requires acc(&raw[InfoFieldOffset(currINF)], _)
-decreases
-pure func ConsDir(raw []byte, currINF int) bool {
-	return raw[InfoFieldOffset(currINF)] & 0x1 == 0x1
-}
-
-ghost 
-requires 0 <= currINF
-requires InfoFieldOffset(currINF) < len(raw)
-requires acc(&raw[InfoFieldOffset(currINF)], _)
-decreases
-pure func Peer(raw []byte, currINF int) bool {
-	return raw[InfoFieldOffset(currINF)] & 0x2 == 0x2
 }

--- a/pkg/slayers/path/infofield_spec.gobra
+++ b/pkg/slayers/path/infofield_spec.gobra
@@ -1,0 +1,50 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +gobra
+
+package path
+
+import (
+    sl "verification/utils/slices"
+	. "verification/utils/definitions"
+)
+
+ghost const MetaLen = 4
+
+ghost
+decreases
+pure func InfoFieldOffset(currINF int) int {
+	return MetaLen + InfoLen * currINF
+}
+
+ghost
+requires 0 <= currINF
+requires InfoFieldOffset(currINF) < len(raw)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
+decreases
+pure func ConsDir(raw []byte, currINF int) bool {
+	return unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55) in
+		raw[InfoFieldOffset(currINF)] & 0x1 == 0x1
+}
+
+ghost
+requires 0 <= currINF
+requires InfoFieldOffset(currINF) < len(raw)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
+decreases
+pure func Peer(raw []byte, currINF int) bool {
+	return unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55) in
+		raw[InfoFieldOffset(currINF)] & 0x2 == 0x2
+}

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1683,8 +1683,8 @@ func (p *scionPacketProcessor) processIntraBFD(data []byte) (res error) {
 // contracts for IO-spec
 // @ requires dp.Valid()
 // @ requires acc(ioLock.LockP(), _) && ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>;
-// @ requires let absPkt := absIO_val(dp, p.rawPkt, p.getIngressID()) in
-// @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.getIngressID()), absPkt.IO_val_Pkt2_2)
+// @ requires let absPkt := absIO_val(dp, p.rawPkt, p.ingressID) in
+// @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.ingressID), absPkt.IO_val_Pkt2_2)
 // @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&
 // @	ElemWitness(ioSharedArg.OBufY, newAbsPkt.IO_val_Pkt2_1, newAbsPkt.IO_val_Pkt2_2)
 // @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1683,8 +1683,8 @@ func (p *scionPacketProcessor) processIntraBFD(data []byte) (res error) {
 // contracts for IO-spec
 // @ requires dp.Valid()
 // @ requires acc(ioLock.LockP(), _) && ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>;
-// @ requires let absPkt := absIO_val(dp, p.rawPkt, p.ingressID) in
-// @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.ingressID), absPkt.IO_val_Pkt2_2)
+// @ requires let absPkt := absIO_val(dp, p.rawPkt, p.getIngressID()) in
+// @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.getIngressID()), absPkt.IO_val_Pkt2_2)
 // @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&
 // @	ElemWitness(ioSharedArg.OBufY, newAbsPkt.IO_val_Pkt2_1, newAbsPkt.IO_val_Pkt2_2)
 // @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1683,8 +1683,10 @@ func (p *scionPacketProcessor) processIntraBFD(data []byte) (res error) {
 // contracts for IO-spec
 // @ requires dp.Valid()
 // @ requires acc(ioLock.LockP(), _) && ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>;
-// @ requires let absPkt := absIO_val(dp, p.rawPkt, p.getIngressID()) in
-// @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.getIngressID()), absPkt.IO_val_Pkt2_2)
+// @ requires acc(&p.ingressID)
+// @ requires let absPkt := absIO_val(dp, p.rawPkt, p.ingressID) in
+// @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.ingressID), absPkt.IO_val_Pkt2_2)
+// @ ensures acc(&p.ingressID)
 // @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&
 // @	ElemWitness(ioSharedArg.OBufY, newAbsPkt.IO_val_Pkt2_1, newAbsPkt.IO_val_Pkt2_2)
 // @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1390,8 +1390,8 @@ func (p *scionPacketProcessor) reset() (err error) {
 // contracts for IO-spec
 // @ requires dp.Valid()
 // @ requires acc(ioLock.LockP(), _) && ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>;
-// @ requires let absPkt := absIO_val(dp, rawPkt, p.getIngressID) in
-// @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.getIngressID), absPkt.IO_val_Pkt2_2)
+// @ requires let absPkt := absIO_val(dp, rawPkt, p.getIngressID()) in
+// @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.getIngressID()), absPkt.IO_val_Pkt2_2)
 // @ ensures reserr == nil && newAbsPkt.isIO_val_Pkt2 ==>
 // @	ElemWitness(ioSharedArg.OBufY, newAbsPkt.IO_val_Pkt2_1, newAbsPkt.IO_val_Pkt2_2)
 // @ ensures reserr == nil && newAbsPkt.isIO_val_Pkt2 ==>

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1683,10 +1683,8 @@ func (p *scionPacketProcessor) processIntraBFD(data []byte) (res error) {
 // contracts for IO-spec
 // @ requires dp.Valid()
 // @ requires acc(ioLock.LockP(), _) && ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>;
-// @ requires acc(&p.ingressID)
-// @ requires let absPkt := absIO_val(dp, p.rawPkt, p.ingressID) in
-// @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.ingressID), absPkt.IO_val_Pkt2_2)
-// @ ensures acc(&p.ingressID)
+// @ requires let absPkt := absIO_val(dp, p.rawPkt, p.getIngressID()) in
+// @	absPkt.isIO_val_Pkt2 ==> ElemWitness(ioSharedArg.IBufY, ifsToIO_ifs(p.getIngressID()), absPkt.IO_val_Pkt2_2)
 // @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&
 // @	ElemWitness(ioSharedArg.OBufY, newAbsPkt.IO_val_Pkt2_1, newAbsPkt.IO_val_Pkt2_2)
 // @ ensures reserr == nil ==> newAbsPkt.isIO_val_Pkt2 &&

--- a/router/io-spec.gobra
+++ b/router/io-spec.gobra
@@ -17,12 +17,13 @@
 package router
 
 import (
-	sl "github.com/scionproto/scion/verification/utils/slices"
-	"github.com/scionproto/scion/verification/io"
-	"github.com/scionproto/scion/verification/dependencies/encoding/binary"
+	sl "verification/utils/slices"
+	"verification/io"
+	"verification/dependencies/encoding/binary"
 	"github.com/scionproto/scion/pkg/slayers/path"
 	"github.com/scionproto/scion/pkg/slayers/path/scion"
 	"github.com/scionproto/scion/private/topology"
+	. "verification/utils/definitions"
 )
 
 ghost
@@ -59,14 +60,13 @@ pure func lengthOfPrevSeg(currHF int, seg1Len int, seg2Len int, seg3Len int) (re
 	return seg1Len > currHF ? 0 : ((seg1Len + seg2Len) > currHF ? seg1Len : seg1Len + seg2Len)
 }
 
-// returns the ASid of a hopfield
+// returns the ASid of the next hopfield
 ghost
 requires 1 <= numINF
 requires 0 <= currHFIdx
 requires hopFieldOffset(numINF, currHFIdx) + path.HopLen <= len(raw)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
 requires dp.Valid()
-requires let idx := hopFieldOffset(numINF, currHFIdx) in
-	acc(&raw[idx+2], _) && acc(&raw[idx+3], _) && acc(&raw[idx+4], _) && acc(&raw[idx+5], _)
 decreases
 pure func asidFromIfs(
 	dp io.DataPlaneSpec,
@@ -76,6 +76,11 @@ pure func asidFromIfs(
 	consDir bool,
 	asid io.IO_as) (res option[io.IO_as]) {
 	return let idx := hopFieldOffset(numINF, currHFIdx) in
+		unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in 
+		let _ := Asserting(forall i int :: { &raw[idx+2+i] } { &raw[idx+2:idx+4][i] } 0 <= i && i < 2 ==> 
+			&raw[idx+2+i] == &raw[idx+2:idx+4][i]) in
+		let _ := Asserting(forall i int :: { &raw[idx+4+i] } { &raw[idx+4:idx+6][i] } 0 <= i && i < 2 ==> 
+			&raw[idx+4+i] == &raw[idx+4:idx+6][i]) in
 		let ifs := consDir ? binary.BigEndian.Uint16(raw[idx+4:idx+6]) : binary.BigEndian.Uint16(raw[idx+2:idx+4]) in
 		let asIfPair := io.AsIfsPair{asid, io.IO_ifs(ifs)} in
 		(asIfPair in domain(dp.GetLinks()) ?
@@ -99,18 +104,18 @@ pure func asidsBefore(
 	prevSegLen int,
 	consDir bool,
 	asid io.IO_as) (res option[seq[io.IO_as]]) {
-	return let next_asid := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in asidFromIfs(dp, raw, numINF, currHFIdx, !consDir, asid)) in
-		match next_asid{
+	return currHFIdx == prevSegLen ? some(seq[io.IO_as]{asid}) :
+		let nextAsid := asidFromIfs(dp, raw, numINF, currHFIdx, !consDir, asid) in
+		match nextAsid{
 			case none[io.IO_as]:
 				none[seq[io.IO_as]]
 			default:
-				currHFIdx == prevSegLen ? some(seq[io.IO_as]{get(next_asid)}) :
-				let next_asid_seq := asidsBefore(dp, raw, numINF, currHFIdx-1, prevSegLen, consDir, get(next_asid)) in
-				match next_asid_seq{
+				let nextAsidSeq := asidsBefore(dp, raw, numINF, currHFIdx-1, prevSegLen, consDir, get(nextAsid)) in
+				match nextAsidSeq{
 					case none[seq[io.IO_as]]:
 						none[seq[io.IO_as]]
 					default:
-						some(get(next_asid_seq) ++ seq[io.IO_as]{get(next_asid)})
+						some(get(nextAsidSeq) ++ seq[io.IO_as]{asid})
 				}
 		}
 }
@@ -132,18 +137,18 @@ pure func asidsAfter(
 	segLen int,
 	consDir bool,
 	asid io.IO_as) (res option[seq[io.IO_as]]) {
-	return let next_asid := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in asidFromIfs(dp, raw, numINF, currHFIdx, consDir, asid)) in
-		match next_asid{
+	return  currHFIdx == segLen - 1 ? some(seq[io.IO_as]{asid}) :
+		let nextAsid := asidFromIfs(dp, raw, numINF, currHFIdx, consDir, asid) in
+		match nextAsid{
 			case none[io.IO_as]:
 				none[seq[io.IO_as]]
 			default:
-				currHFIdx == segLen - 1 ? some(seq[io.IO_as]{get(next_asid)}) :
-				let next_asid_seq := asidsAfter(dp, raw, numINF, currHFIdx+1, segLen, consDir, get(next_asid)) in
-				match next_asid_seq{
+				let nextAsidSeq := asidsAfter(dp, raw, numINF, currHFIdx+1, segLen, consDir, get(nextAsid)) in
+				match nextAsidSeq{
 					case none[seq[io.IO_as]]:
 						none[seq[io.IO_as]]
 					default:
-						some(seq[io.IO_as]{get(next_asid)} ++ get(next_asid_seq))
+						some(seq[io.IO_as]{asid} ++ get(nextAsidSeq))
 				}
 		}
 }
@@ -247,11 +252,16 @@ pure func asidsForMidSeg(dp io.DataPlaneSpec, raw []byte, numINF int, currINFIdx
 ghost
 requires idx + path.HopLen <= len(raw)
 requires 0 <= idx
-requires acc(&raw[idx+2], _) && acc(&raw[idx+3], _) && acc(&raw[idx+4], _) && acc(&raw[idx+5], _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
 ensures  len(res.HVF.MsgTerm_Hash_.MsgTerm_MPair_2.MsgTerm_L_) > 0
 decreases
 pure func hopField(raw []byte, idx int, beta set[io.IO_msgterm], asid io.IO_as, ainfo io.IO_ainfo) (res io.IO_HF) {
-	return let inif2 := binary.BigEndian.Uint16(raw[idx+2:idx+4]) in
+	return unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in 
+		let _ := Asserting(forall i int :: { &raw[idx+2+i] } { &raw[idx+2:idx+4][i] } 0 <= i && i < 2 ==> 
+			&raw[idx+2+i] == &raw[idx+2:idx+4][i]) in
+		let _ := Asserting(forall i int :: { &raw[idx+4+i] } { &raw[idx+4:idx+6][i] } 0 <= i && i < 2 ==> 
+			&raw[idx+4+i] == &raw[idx+4:idx+6][i]) in
+		let inif2 := binary.BigEndian.Uint16(raw[idx+2:idx+4]) in
 		let egif2 := binary.BigEndian.Uint16(raw[idx+4:idx+6]) in
 		let op_inif2 := inif2 == 0 ? none[io.IO_ifs] : some(io.IO_ifs(inif2)) in
 		let op_egif2 := egif2 == 0 ? none[io.IO_ifs] : some(io.IO_ifs(egif2)) in
@@ -274,6 +284,8 @@ requires  acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
 ensures   len(res) == len(asid) - currHFIdx
 ensures   forall k int :: {res[k]} 0 <= k && k < len(res) ==>
 	len(res[k].HVF.MsgTerm_Hash_.MsgTerm_MPair_2.MsgTerm_L_) > 0
+ensures   forall k int :: {res[k]} 0 <= k && k < len(res) ==>
+	res[k].extr_asid() == asid[k + currHFIdx]
 decreases len(asid) - currHFIdx
 pure func hopFieldsConsDir(
 	raw []byte,
@@ -283,8 +295,7 @@ pure func hopFieldsConsDir(
 	asid seq[io.IO_as],
 	ainfo io.IO_ainfo) (res seq[io.IO_HF]) {
 	return currHFIdx == len(asid) ? seq[io.IO_HF]{} :
-		let hf := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in
-			hopField(raw, offset + path.HopLen * currHFIdx, beta, asid[currHFIdx], ainfo)) in
+		let hf := hopField(raw, offset + path.HopLen * currHFIdx, beta, asid[currHFIdx], ainfo) in
 		seq[io.IO_HF]{hf} ++ hopFieldsConsDir(raw, offset, currHFIdx + 1, (beta union set[io.IO_msgterm]{hf.HVF}), asid, ainfo)
 }
 
@@ -296,6 +307,8 @@ requires  acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
 ensures   len(res) == currHFIdx + 1
 ensures   forall k int :: {res[k]} 0 <= k && k < len(res) ==>
 	len(res[k].HVF.MsgTerm_Hash_.MsgTerm_MPair_2.MsgTerm_L_) > 0
+ensures   forall k int :: {res[k]} 0 <= k && k < len(res) ==>
+	res[k].extr_asid() == asid[k]
 decreases currHFIdx + 1
 pure func hopFieldsNotConsDir(
 	raw []byte,
@@ -305,9 +318,8 @@ pure func hopFieldsNotConsDir(
 	asid seq[io.IO_as],
 	ainfo io.IO_ainfo) (res seq[io.IO_HF]) {
 	return currHFIdx == -1 ? seq[io.IO_HF]{} :
-		let hf := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in
-			hopField(raw, offset + path.HopLen * currHFIdx, beta, asid[currHFIdx], ainfo)) in
-		hopFieldsNotConsDir(raw, offset, currHFIdx -1, (beta union set[io.IO_msgterm]{hf.HVF}), asid, ainfo) ++ seq[io.IO_HF]{hf}
+		let hf := hopField(raw, offset + path.HopLen * currHFIdx, beta, asid[currHFIdx], ainfo) in
+		hopFieldsNotConsDir(raw, offset, currHFIdx - 1, (beta union set[io.IO_msgterm]{hf.HVF}), asid, ainfo) ++ seq[io.IO_HF]{hf}
 }
 
 ghost

--- a/router/io-spec.gobra
+++ b/router/io-spec.gobra
@@ -597,6 +597,7 @@ pure func absIO_val_Unsupported(raw []byte, ingressID uint16) (val io.IO_val) {
 }
 
 ghost
+opaque
 requires dp.Valid()
 requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
 ensures val.isIO_val_Pkt2 || val.isIO_val_Unsupported

--- a/router/io-spec.gobra
+++ b/router/io-spec.gobra
@@ -155,6 +155,7 @@ pure func asidsAfter(
 
 // returns a list of ASids of hopfields for CurrSeg in the abstract packet
 ghost
+opaque
 requires 1 <= numINF
 requires 0 <= prevSegLen && prevSegLen <= currHFIdx
 requires currHFIdx < segLen
@@ -162,7 +163,6 @@ requires hopFieldOffset(numINF, segLen) <= len(raw)
 requires dp.Valid()
 requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R56)
 ensures res != none[seq[io.IO_as]] ==> len(get(res)) == segLen - prevSegLen
-opaque
 decreases
 pure func asidForCurrSeg(
 	dp io.DataPlaneSpec,
@@ -183,6 +183,7 @@ pure func asidForCurrSeg(
 
 // returns a list of ASids of hopfields for LeftSeg in the abstract packet
 ghost
+opaque
 requires dp.Valid()
 requires 1 <= numINF
 requires 0 < seg1Len
@@ -194,7 +195,6 @@ requires 1 <= currINFIdx && currINFIdx < 4
 requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R56)
 ensures (currINFIdx == 1 && seg2Len > 0 && res != none[seq[io.IO_as]]) ==> len(get(res)) == seg2Len
 ensures (currINFIdx == 2 && seg2Len > 0 && seg3Len > 0 && res != none[seq[io.IO_as]]) ==> len(get(res)) == seg3Len
-opaque
 decreases
 pure func asidsForLeftSeg(dp io.DataPlaneSpec, raw []byte, numINF int, currINFIdx int, seg1Len int, seg2Len int, seg3Len int, asid io.IO_as) (res option[seq[io.IO_as]]) {
 	return let consDir := path.ConsDir(raw, currINFIdx) in
@@ -207,6 +207,7 @@ pure func asidsForLeftSeg(dp io.DataPlaneSpec, raw []byte, numINF int, currINFId
 
 // returns a list of ASids of hopfields for RightSeg in the abstract packet
 ghost
+opaque
 requires dp.Valid()
 requires 1 <= numINF
 requires 0 < seg1Len
@@ -218,7 +219,6 @@ requires -1 <= currINFIdx && currINFIdx < 2
 requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R56)
 ensures (currINFIdx == 0 && res != none[seq[io.IO_as]]) ==> len(get(res)) == seg1Len
 ensures (currINFIdx == 1 && seg2Len > 0 && res != none[seq[io.IO_as]]) ==> len(get(res)) == seg2Len
-opaque
 decreases
 pure func asidsForRightSeg(dp io.DataPlaneSpec, raw []byte, numINF int, currINFIdx int, seg1Len int, seg2Len int, seg3Len int, asid io.IO_as) (res option[seq[io.IO_as]]) {
 	return (currINFIdx == 1 && seg2Len > 0) ?
@@ -232,6 +232,7 @@ pure func asidsForRightSeg(dp io.DataPlaneSpec, raw []byte, numINF int, currINFI
 
 // returns a list of ASids of hopfields for MidSeg in the abstract packet
 ghost
+opaque
 requires dp.Valid()
 requires 1 <= numINF
 requires 0 < seg1Len
@@ -245,7 +246,6 @@ requires (currINFIdx == 4 && seg2Len > 0) ==> asid != none[io.IO_as]
 requires (currINFIdx == 2 && seg2Len > 0 && seg3Len > 0) ==> asid != none[io.IO_as]
 ensures	 (currINFIdx == 4 && seg2Len > 0 && res != none[seq[io.IO_as]]) ==> len(get(res)) == seg1Len
 ensures	 (currINFIdx == 2 && seg2Len > 0 && seg3Len > 0 && res != none[seq[io.IO_as]]) ==> len(get(res)) == seg3Len
-opaque
 decreases
 pure func asidsForMidSeg(dp io.DataPlaneSpec, raw []byte, numINF int, currINFIdx int, seg1Len int, seg2Len int, seg3Len int, asid option[io.IO_as]) (res option[seq[io.IO_as]]) {
 	return (currINFIdx == 4 && seg2Len > 0) ?
@@ -385,13 +385,13 @@ pure func segment(raw []byte,
 }
 
 ghost
+opaque
 requires path.InfoFieldOffset(currINFIdx) + path.InfoLen <= offset
 requires 0 < len(asid)
 requires offset + path.HopLen * len(asid) <= len(raw)
 requires 0 <= currHFIdx && currHFIdx <= len(asid)
 requires 0 <= currINFIdx && currINFIdx < 3
 requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R56)
-opaque
 decreases
 pure func currSeg(raw []byte, offset int, currINFIdx int, currHFIdx int, asid seq[io.IO_as]) io.IO_seg3 {
 	return let ainfo := timestamp(raw, currINFIdx) in
@@ -401,6 +401,7 @@ pure func currSeg(raw []byte, offset int, currINFIdx int, currHFIdx int, asid se
 }
 
 ghost
+opaque
 requires 0 < seg1Len
 requires 0 <= seg2Len
 requires 0 <= seg3Len
@@ -409,7 +410,6 @@ requires 1 <= currINFIdx && currINFIdx < 4
 requires (currINFIdx == 1 && seg2Len > 0) ==> len(asid) == seg2Len
 requires (currINFIdx == 2 && seg2Len > 0 && seg3Len > 0) ==> len(asid) == seg3Len
 requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R56)
-opaque
 decreases
 pure func leftSeg(
 	raw []byte,
@@ -427,6 +427,7 @@ pure func leftSeg(
 }
 
 ghost
+opaque
 requires 0 < seg1Len
 requires 0 <= seg2Len
 requires 0 <= seg3Len
@@ -435,7 +436,6 @@ requires -1 <= currINFIdx && currINFIdx < 2
 requires (currINFIdx == 1 && seg2Len > 0 && seg3Len > 0) ==> len(asid) == seg2Len
 requires (currINFIdx == 0 && seg2Len > 0) ==> len(asid) == seg1Len
 requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R56)
-opaque
 decreases
 pure func rightSeg(
 	raw []byte,
@@ -453,6 +453,7 @@ pure func rightSeg(
 }
 
 ghost
+opaque
 requires 0 < seg1Len
 requires 0 <= seg2Len
 requires 0 <= seg3Len
@@ -461,7 +462,6 @@ requires 2 <= currINFIdx && currINFIdx < 5
 requires (currINFIdx == 4 && seg2Len > 0) ==> len(asid) == seg1Len
 requires (currINFIdx == 2 && seg2Len > 0 && seg3Len > 0) ==> len(asid) == seg3Len
 requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R56)
-opaque
 decreases
 pure func midSeg(
 	raw []byte,
@@ -479,10 +479,10 @@ pure func midSeg(
 }
 
 ghost
+opaque
 requires dp.Valid()
 requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R56)
 requires validPktMetaHdr(raw)
-opaque
 decreases
 pure func absPkt(dp io.DataPlaneSpec, raw []byte) (res option[io.IO_pkt2]) {
 	return let _ := reveal validPktMetaHdr(raw) in

--- a/router/io-spec.gobra
+++ b/router/io-spec.gobra
@@ -65,7 +65,7 @@ ghost
 requires 1 <= numINF
 requires 0 <= currHFIdx
 requires hopFieldOffset(numINF, currHFIdx) + path.HopLen <= len(raw)
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 requires dp.Valid()
 decreases
 pure func asidFromIfs(
@@ -76,10 +76,10 @@ pure func asidFromIfs(
 	consDir bool,
 	asid io.IO_as) (res option[io.IO_as]) {
 	return let idx := hopFieldOffset(numINF, currHFIdx) in
-		unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in 
-		let _ := Asserting(forall i int :: { &raw[idx+2+i] } { &raw[idx+2:idx+4][i] } 0 <= i && i < 2 ==> 
+		unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55) in
+		let _ := Asserting(forall i int :: { &raw[idx+2+i] } { &raw[idx+2:idx+4][i] } 0 <= i && i < 2 ==>
 			&raw[idx+2+i] == &raw[idx+2:idx+4][i]) in
-		let _ := Asserting(forall i int :: { &raw[idx+4+i] } { &raw[idx+4:idx+6][i] } 0 <= i && i < 2 ==> 
+		let _ := Asserting(forall i int :: { &raw[idx+4+i] } { &raw[idx+4:idx+6][i] } 0 <= i && i < 2 ==>
 			&raw[idx+4+i] == &raw[idx+4:idx+6][i]) in
 		let ifs := consDir ? binary.BigEndian.Uint16(raw[idx+4:idx+6]) : binary.BigEndian.Uint16(raw[idx+2:idx+4]) in
 		let asIfPair := io.AsIfsPair{asid, io.IO_ifs(ifs)} in
@@ -93,7 +93,7 @@ requires 1 <= numINF
 requires 0 <= prevSegLen && prevSegLen <= currHFIdx
 requires hopFieldOffset(numINF, currHFIdx) + path.HopLen <= len(raw)
 requires dp.Valid()
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 ensures res != none[seq[io.IO_as]] ==> len(get(res)) == currHFIdx - prevSegLen + 1
 decreases currHFIdx - prevSegLen
 pure func asidsBefore(
@@ -126,7 +126,7 @@ requires 1 <= numINF
 requires 0 <= currHFIdx && currHFIdx < segLen
 requires hopFieldOffset(numINF, segLen) <= len(raw)
 requires dp.Valid()
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 ensures res != none[seq[io.IO_as]] ==> len(get(res)) == segLen - currHFIdx
 decreases segLen - currHFIdx + 1
 pure func asidsAfter(
@@ -160,8 +160,9 @@ requires 0 <= prevSegLen && prevSegLen <= currHFIdx
 requires currHFIdx < segLen
 requires hopFieldOffset(numINF, segLen) <= len(raw)
 requires dp.Valid()
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 ensures res != none[seq[io.IO_as]] ==> len(get(res)) == segLen - prevSegLen
+opaque
 decreases
 pure func asidForCurrSeg(
 	dp io.DataPlaneSpec,
@@ -190,10 +191,13 @@ requires 0 <= seg3Len
 requires hopFieldOffset(numINF, seg1Len + seg2Len + seg3Len) <= len(raw)
 requires currINFIdx <= numINF + 1
 requires 1 <= currINFIdx && currINFIdx < 4
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
+ensures (currINFIdx == 1 && seg2Len > 0 && res != none[seq[io.IO_as]]) ==> len(get(res)) == seg2Len
+ensures (currINFIdx == 2 && seg2Len > 0 && seg3Len > 0 && res != none[seq[io.IO_as]]) ==> len(get(res)) == seg3Len
+opaque
 decreases
 pure func asidsForLeftSeg(dp io.DataPlaneSpec, raw []byte, numINF int, currINFIdx int, seg1Len int, seg2Len int, seg3Len int, asid io.IO_as) (res option[seq[io.IO_as]]) {
-	return let consDir := unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in path.ConsDir(raw, currINFIdx) in
+	return let consDir := path.ConsDir(raw, currINFIdx) in
 		(currINFIdx == 1 && seg2Len > 0) ?
 			asidForCurrSeg(dp, raw, numINF, seg1Len, seg1Len+seg2Len, seg1Len, consDir, asid) :
 			(currINFIdx == 2 && seg2Len > 0 && seg3Len > 0) ?
@@ -211,16 +215,17 @@ requires 0 <= seg3Len
 requires hopFieldOffset(numINF, seg1Len + seg2Len + seg3Len) <= len(raw)
 requires currINFIdx <= numINF + 1
 requires -1 <= currINFIdx && currINFIdx < 2
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 ensures (currINFIdx == 0 && res != none[seq[io.IO_as]]) ==> len(get(res)) == seg1Len
 ensures (currINFIdx == 1 && seg2Len > 0 && res != none[seq[io.IO_as]]) ==> len(get(res)) == seg2Len
+opaque
 decreases
 pure func asidsForRightSeg(dp io.DataPlaneSpec, raw []byte, numINF int, currINFIdx int, seg1Len int, seg2Len int, seg3Len int, asid io.IO_as) (res option[seq[io.IO_as]]) {
 	return (currINFIdx == 1 && seg2Len > 0) ?
-		let consDir := unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in path.ConsDir(raw, currINFIdx) in
+		let consDir := path.ConsDir(raw, currINFIdx) in
 		asidForCurrSeg(dp, raw, numINF, seg1Len+seg2Len-1, seg1Len+seg2Len, seg1Len, consDir, asid) :
 		(currINFIdx == 0) ?
-			let consDir := unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in path.ConsDir(raw, currINFIdx) in
+			let consDir := path.ConsDir(raw, currINFIdx) in
 			asidForCurrSeg(dp, raw, numINF, seg1Len-1, seg1Len, 0, consDir, asid) :
 			some(seq[io.IO_as]{})
 }
@@ -235,16 +240,19 @@ requires 0 <= seg3Len
 requires hopFieldOffset(numINF, seg1Len + seg2Len + seg3Len) <= len(raw)
 requires currINFIdx <= numINF + 1
 requires 2 <= currINFIdx && currINFIdx < 5
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 requires (currINFIdx == 4 && seg2Len > 0) ==> asid != none[io.IO_as]
 requires (currINFIdx == 2 && seg2Len > 0 && seg3Len > 0) ==> asid != none[io.IO_as]
+ensures	 (currINFIdx == 4 && seg2Len > 0 && res != none[seq[io.IO_as]]) ==> len(get(res)) == seg1Len
+ensures	 (currINFIdx == 2 && seg2Len > 0 && seg3Len > 0 && res != none[seq[io.IO_as]]) ==> len(get(res)) == seg3Len
+opaque
 decreases
 pure func asidsForMidSeg(dp io.DataPlaneSpec, raw []byte, numINF int, currINFIdx int, seg1Len int, seg2Len int, seg3Len int, asid option[io.IO_as]) (res option[seq[io.IO_as]]) {
 	return (currINFIdx == 4 && seg2Len > 0) ?
-		let consDir := unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in path.ConsDir(raw, 1) in
+		let consDir := path.ConsDir(raw, 1) in
 		asidForCurrSeg(dp, raw, numINF, seg1Len-1, seg1Len, 0, consDir, get(asid)) :
 		(currINFIdx == 2 && seg2Len > 0 && seg3Len > 0) ?
-			let consDir := unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in path.ConsDir(raw, 2) in
+			let consDir := path.ConsDir(raw, 2) in
 			asidForCurrSeg(dp, raw, numINF, seg1Len + seg2Len, seg1Len + seg2Len + seg3Len, seg1Len + seg2Len, consDir, get(asid)) :
 			some(seq[io.IO_as]{})
 }
@@ -252,14 +260,14 @@ pure func asidsForMidSeg(dp io.DataPlaneSpec, raw []byte, numINF int, currINFIdx
 ghost
 requires idx + path.HopLen <= len(raw)
 requires 0 <= idx
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 ensures  len(res.HVF.MsgTerm_Hash_.MsgTerm_MPair_2.MsgTerm_L_) > 0
 decreases
 pure func hopField(raw []byte, idx int, beta set[io.IO_msgterm], asid io.IO_as, ainfo io.IO_ainfo) (res io.IO_HF) {
-	return unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in 
-		let _ := Asserting(forall i int :: { &raw[idx+2+i] } { &raw[idx+2:idx+4][i] } 0 <= i && i < 2 ==> 
+	return unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55) in
+		let _ := Asserting(forall i int :: { &raw[idx+2+i] } { &raw[idx+2:idx+4][i] } 0 <= i && i < 2 ==>
 			&raw[idx+2+i] == &raw[idx+2:idx+4][i]) in
-		let _ := Asserting(forall i int :: { &raw[idx+4+i] } { &raw[idx+4:idx+6][i] } 0 <= i && i < 2 ==> 
+		let _ := Asserting(forall i int :: { &raw[idx+4+i] } { &raw[idx+4:idx+6][i] } 0 <= i && i < 2 ==>
 			&raw[idx+4+i] == &raw[idx+4:idx+6][i]) in
 		let inif2 := binary.BigEndian.Uint16(raw[idx+2:idx+4]) in
 		let egif2 := binary.BigEndian.Uint16(raw[idx+4:idx+6]) in
@@ -280,7 +288,7 @@ ghost
 requires  0 <= offset
 requires  0 <= currHFIdx && currHFIdx <= len(asid)
 requires  offset + path.HopLen * len(asid) <= len(raw)
-requires  acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires  acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 ensures   len(res) == len(asid) - currHFIdx
 ensures   forall k int :: {res[k]} 0 <= k && k < len(res) ==>
 	len(res[k].HVF.MsgTerm_Hash_.MsgTerm_MPair_2.MsgTerm_L_) > 0
@@ -303,7 +311,7 @@ ghost
 requires  0 <= offset
 requires  -1 <= currHFIdx && currHFIdx < len(asid)
 requires  offset + path.HopLen * currHFIdx + path.HopLen <= len(raw)
-requires  acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires  acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 ensures   len(res) == currHFIdx + 1
 ensures   forall k int :: {res[k]} 0 <= k && k < len(res) ==>
 	len(res[k].HVF.MsgTerm_Hash_.MsgTerm_MPair_2.MsgTerm_L_) > 0
@@ -352,7 +360,7 @@ requires 0 <= offset
 requires 0 < len(asid)
 requires offset + path.HopLen * len(asid) <= len(raw)
 requires 0 <= currHFIdx && currHFIdx <= len(asid)
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 decreases
 pure func segment(raw []byte,
 	offset int,
@@ -382,11 +390,11 @@ requires 0 < len(asid)
 requires offset + path.HopLen * len(asid) <= len(raw)
 requires 0 <= currHFIdx && currHFIdx <= len(asid)
 requires 0 <= currINFIdx && currINFIdx < 3
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
+opaque
 decreases
 pure func currSeg(raw []byte, offset int, currINFIdx int, currHFIdx int, asid seq[io.IO_as]) io.IO_seg3 {
-	return unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in
-		let ainfo := timestamp(raw, currINFIdx) in
+	return let ainfo := timestamp(raw, currINFIdx) in
 		let consDir := path.ConsDir(raw, currINFIdx) in
 		let peer := path.Peer(raw, currINFIdx) in
 		segment(raw, offset, currHFIdx, asid, ainfo, consDir, peer)
@@ -400,7 +408,8 @@ requires pktLen(seg1Len, seg2Len, seg3Len) <= len(raw)
 requires 1 <= currINFIdx && currINFIdx < 4
 requires (currINFIdx == 1 && seg2Len > 0) ==> len(asid) == seg2Len
 requires (currINFIdx == 2 && seg2Len > 0 && seg3Len > 0) ==> len(asid) == seg3Len
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
+opaque
 decreases
 pure func leftSeg(
 	raw []byte,
@@ -425,7 +434,8 @@ requires pktLen(seg1Len, seg2Len, seg3Len) <= len(raw)
 requires -1 <= currINFIdx && currINFIdx < 2
 requires (currINFIdx == 1 && seg2Len > 0 && seg3Len > 0) ==> len(asid) == seg2Len
 requires (currINFIdx == 0 && seg2Len > 0) ==> len(asid) == seg1Len
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
+opaque
 decreases
 pure func rightSeg(
 	raw []byte,
@@ -450,7 +460,8 @@ requires pktLen(seg1Len, seg2Len, seg3Len) <= len(raw)
 requires 2 <= currINFIdx && currINFIdx < 5
 requires (currINFIdx == 4 && seg2Len > 0) ==> len(asid) == seg1Len
 requires (currINFIdx == 2 && seg2Len > 0 && seg3Len > 0) ==> len(asid) == seg3Len
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
+opaque
 decreases
 pure func midSeg(
 	raw []byte,
@@ -469,25 +480,15 @@ pure func midSeg(
 
 ghost
 requires dp.Valid()
-requires len(raw) > 4
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
-requires unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in
-	let hdr := binary.BigEndian.Uint32(raw[0:4]) in
-	let metaHdr := scion.DecodedFrom(hdr) in
-	let seg1 := int(metaHdr.SegLen[0]) in
-	let seg2 := int(metaHdr.SegLen[1]) in
-	let seg3 := int(metaHdr.SegLen[2]) in
-	let base := scion.Base{metaHdr,
-		numInfoFields(seg1, seg2, seg3),
-		seg1 + seg2 + seg3} in
-	metaHdr.InBounds() &&
-	0 < metaHdr.SegLen[0] &&
-	base.ValidCurrInfSpec() &&
-	base.ValidCurrHfSpec() &&
-	len(raw) >= pktLen(seg1, seg2, seg3)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
+requires validPktMetaHdr(raw)
+//ensures res != none[io.IO_pkt2] ==> len(get(res).CurrSeg.Future) > 0
+//ensures res != none[io.IO_pkt2] ==> get(res).CurrSeg.Future[0].extr_asid() == dp.Asid()
+opaque
 decreases
-pure func absPkt(dp io.DataPlaneSpec, raw []byte, asid io.IO_as) option[io.IO_pkt2] {
-	return let hdr := unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in binary.BigEndian.Uint32(raw[0:4]) in
+pure func absPkt(dp io.DataPlaneSpec, raw []byte, asid io.IO_as) (res option[io.IO_pkt2]) {
+	return let _ := reveal validPktMetaHdr(raw) in
+		let hdr := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55) in binary.BigEndian.Uint32(raw[0:4])) in
 		let metaHdr := scion.DecodedFrom(hdr) in
 		let currINFIdx := int(metaHdr.CurrINF) in
 		let currHFIdx := int(metaHdr.CurrHF) in
@@ -498,7 +499,7 @@ pure func absPkt(dp io.DataPlaneSpec, raw []byte, asid io.IO_as) option[io.IO_pk
 		let prevSegLen := lengthOfPrevSeg(currHFIdx, seg1Len, seg2Len, seg3Len) in
 		let numINF := numInfoFields(seg1Len, seg2Len, seg3Len) in
 		let offset := hopFieldOffset(numINF, 0) in
-		let consDir := unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in path.ConsDir(raw, currINFIdx) in
+		let consDir := path.ConsDir(raw, currINFIdx) in
 		let currAsidSeq := asidForCurrSeg(dp, raw, numINF, currHFIdx, prevSegLen+segLen, prevSegLen, consDir, dp.Asid()) in
 		currAsidSeq == none[seq[io.IO_as]] ? none[io.IO_pkt2] :
 			let last := get(currAsidSeq)[segLen-1] in
@@ -522,13 +523,13 @@ pure func absPkt(dp io.DataPlaneSpec, raw []byte, asid io.IO_as) option[io.IO_pk
 ghost
 requires 0 <= offset
 requires path.InfoFieldOffset(offset) + 8 < len(raw)
-requires acc(&raw[path.InfoFieldOffset(offset) + 4], _)
-requires acc(&raw[path.InfoFieldOffset(offset) + 5], _)
-requires acc(&raw[path.InfoFieldOffset(offset) + 6], _)
-requires acc(&raw[path.InfoFieldOffset(offset) + 7], _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 decreases
 pure func timestamp(raw []byte, offset int) io.IO_ainfo {
 	return let idx := path.InfoFieldOffset(offset) + 4 in
+		unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55) in
+		let _ := Asserting(forall i int :: { &raw[idx+i] } { &raw[idx:idx+4][i] } 0 <= i && i < 4 ==>
+		&raw[idx+i] == &raw[idx:idx+4][i]) in
 		io.IO_ainfo(binary.BigEndian.Uint32(raw[idx : idx + 4]))
 }
 
@@ -564,11 +565,11 @@ pure func ifsToIO_ifs(ifs uint16) option[io.IO_ifs]{
 
 ghost
 opaque
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 decreases
 pure func validPktMetaHdr(raw []byte) bool {
 	return len(raw) > 4 &&
-		unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _) in
+		unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55) in
 		let hdr := binary.BigEndian.Uint32(raw[0:4]) in
 		let metaHdr := scion.DecodedFrom(hdr) in
 		let seg1 := int(metaHdr.SegLen[0]) in
@@ -585,7 +586,7 @@ pure func validPktMetaHdr(raw []byte) bool {
 }
 
 ghost
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 ensures val.isIO_val_Unsupported
 ensures val.IO_val_Unsupported_1 == ifsToIO_ifs(ingressID)
 decreases
@@ -599,7 +600,7 @@ pure func absIO_val_Unsupported(raw []byte, ingressID uint16) (val io.IO_val) {
 ghost
 opaque
 requires dp.Valid()
-requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), _)
+requires acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
 ensures val.isIO_val_Pkt2 || val.isIO_val_Unsupported
 decreases
 pure func absIO_val(dp io.DataPlaneSpec, raw []byte, ingressID uint16) (val io.IO_val) {
@@ -609,7 +610,7 @@ pure func absIO_val(dp io.DataPlaneSpec, raw []byte, ingressID uint16) (val io.I
 }
 
 ghost
-requires acc(&d.localIA, _)
+requires acc(&d.localIA, R55)
 decreases
 pure func (d *DataPlane) dpSpecWellConfiguredLocalIA(dp io.DataPlaneSpec) bool {
 	return io.IO_as(d.localIA) == dp.Asid()


### PR DESCRIPTION
- moved `absInfofield` functions from `hopfield_spec.gobra`to` infofield_spec.gobra`
- added opaque to `absPkt` and subsequent functions