### PR TITLE
Increase timeout for the `experimental/epic` package

### DIFF
--- a/.github/workflows/gobra.yml
+++ b/.github/workflows/gobra.yml
@@ -81,7 +81,7 @@ jobs:
         uses: viperproject/gobra-action@main
         with:
           packages: 'pkg/experimental/epic'
-          timeout: 5m
+          timeout: 7m
           headerOnly: ${{ env.headerOnly }}
           module: ${{ env.module }}
           includePaths: ${{ env.includePaths }}


### PR DESCRIPTION
It seems that we have some kind of performance regression in silicon that causes the package `experimental/epic` to timeout. This PR bumps, for now, the timeout so that we can continue making progress while we figure out what caused this.