### PR TITLE
Use artificial triggers for quantifiers inside IO resources

### DIFF
--- a/router/dataplane_concurrency_model.gobra
+++ b/router/dataplane_concurrency_model.gobra
@@ -98,7 +98,6 @@ pure func MultiReadBioCorrectIfs(
 		} && MultiReadBioCorrectIfs(io.dp3s_iospec_bio3s_recv_T(t), expectedPkts-1, k)
 }
 
-
 ghost
 requires 0 <= expectedPkts && MultiReadBio(t, expectedPkts)
 ensures len(res) == expectedPkts

--- a/verification/io/io-spec.gobra
+++ b/verification/io/io-spec.gobra
@@ -18,8 +18,11 @@
 
 package io
 
-// Unlike the original IO-spec from Isabelle, we need additional information about the network topology. 
-// To ensure the well-formedness of all map accesses we require an additional conjunction 
+// called BogusTrigger instead of Unit here because the name Unit is already in use.
+type BogusTrigger struct{}
+
+// Unlike the original IO-spec from Isabelle, we need additional information about the network topology.
+// To ensure the well-formedness of all map accesses we require an additional conjunction
 // for all the events (dp.Valid())
 
 // This is the main IO Specification.
@@ -119,19 +122,27 @@ pure func (dp DataPlaneSpec) dp3s_iospec_bio3s_enter_guard(s IO_dp3s_state_local
 }
 
 pred (dp DataPlaneSpec) dp3s_iospec_bio3s_enter(s IO_dp3s_state_local, t Place) {
-	// TODO: we may need more triggering terms here
-	forall v IO_val :: { dp.dp3s_iospec_bio3s_enter_guard(s, t, v) } (
+	forall v IO_val :: { TriggerBodyIoEnter(v) } (
 		match v {
-			case IO_Internal_val1{_, _, ?newpkt, ?nextif}: 
+			case IO_Internal_val1{_, _, ?newpkt, ?nextif}:
+				// Gobra requires the triggering term to occur inside the qtfier body,
+				// otherwise we get an error in the call to CBio_IN_bio3s_enter_T.
+				// We named the variable `_ignored` because using `_` here leads to a strange
+				// type error.
+				let _ignored := TriggerBodyIoEnter(v) in
 				(dp.Valid() && dp.dp3s_iospec_bio3s_enter_guard(s, t, v) ==>
-				(CBio_IN_bio3s_enter(t, v) &&
-				dp.dp3s_iospec_ordered(
-					dp3s_add_obuf(s, nextif, newpkt),
-					CBio_IN_bio3s_enter_T(t, v))))
-			default: 
+					(CBio_IN_bio3s_enter(t, v) &&
+					dp.dp3s_iospec_ordered(
+						dp3s_add_obuf(s, nextif, newpkt),
+						CBio_IN_bio3s_enter_T(t, v))))
+			default:
 				true
 		})
 }
+
+ghost
+decreases
+pure func TriggerBodyIoEnter(v IO_val) BogusTrigger { return BogusTrigger{} }
 
 pred CBio_IN_bio3s_xover_up2down(t Place, v IO_val)
 
@@ -146,11 +157,11 @@ requires v.isIO_Internal_val1
 requires dp.Valid()
 decreases
 pure func (dp DataPlaneSpec) dp3s_iospec_bio3s_xover_up2down_guard(s IO_dp3s_state_local, t Place, v IO_val) bool {
-	return let currseg := v.IO_Internal_val1_1.CurrSeg in 
+	return let currseg := v.IO_Internal_val1_1.CurrSeg in
 		match v.IO_Internal_val1_1.LeftSeg{
-			case none[IO_seg2]: 
+			case none[IO_seg2]:
 				false
-			default: 
+			default:
 				let nextseg := get(v.IO_Internal_val1_1.LeftSeg) in
 				(!currseg.ConsDir &&
 				nextseg.ConsDir &&
@@ -176,18 +187,27 @@ pure func (dp DataPlaneSpec) dp3s_iospec_bio3s_xover_up2down_guard(s IO_dp3s_sta
 }
 
 pred (dp DataPlaneSpec) dp3s_iospec_bio3s_xover_up2down(s IO_dp3s_state_local, t Place) {
-	forall v IO_val :: { dp.dp3s_iospec_bio3s_xover_up2down_guard(s, t, v) }{ CBio_IN_bio3s_xover_up2down(t, v) } { dp.dp3s_iospec_ordered(dp3s_add_obuf(s, v.IO_Internal_val1_4, v.IO_Internal_val1_3), dp3s_iospec_bio3s_xover_up2down_T(t, v)) } (
+	forall v IO_val :: { TriggerBodyIoXoverUp2Down(v) } (
 		match v {
-			case IO_Internal_val1{_, _, ?newpkt, ?nextif}: 
+			case IO_Internal_val1{_, _, ?newpkt, ?nextif}:
+				// Gobra requires the triggering term to occur inside the qtfier body,
+				// otherwise we get an error in the call to dp3s_iospec_bio3s_xover_up2down_T.
+				// We named the variable `_ignored` because using `_` here leads to a strange
+				// type error.
+				let _ignored := TriggerBodyIoXoverUp2Down(v) in
 				(dp.Valid() && dp.dp3s_iospec_bio3s_xover_up2down_guard(s, t, v) ==>
-				(CBio_IN_bio3s_xover_up2down(t, v) &&
-				dp.dp3s_iospec_ordered(
-					dp3s_add_obuf(s, nextif, newpkt),
-					dp3s_iospec_bio3s_xover_up2down_T(t, v))))
-			default: 
+					(CBio_IN_bio3s_xover_up2down(t, v) &&
+					dp.dp3s_iospec_ordered(
+						dp3s_add_obuf(s, nextif, newpkt),
+						dp3s_iospec_bio3s_xover_up2down_T(t, v))))
+			default:
 				true
 		})
 }
+
+ghost
+decreases
+pure func TriggerBodyIoXoverUp2Down(v IO_val) BogusTrigger { return BogusTrigger{} }
 
 pred CBio_IN_bio3s_xover_core(t Place, v IO_val)
 
@@ -205,9 +225,9 @@ pure func (dp DataPlaneSpec) dp3s_iospec_bio3s_xover_core_guard(s IO_dp3s_state_
 	return (dp.Asid() in dp.Core() &&
 		let currseg := v.IO_Internal_val1_1.CurrSeg in
 		match v.IO_Internal_val1_1.LeftSeg {
-			case none[IO_seg2]: 
+			case none[IO_seg2]:
 				false
-			default: 
+			default:
 				let nextseg := get(v.IO_Internal_val1_1.LeftSeg) in
 				currseg.ConsDir == nextseg.ConsDir &&
 				len(nextseg.Future) > 0 &&
@@ -232,18 +252,27 @@ pure func (dp DataPlaneSpec) dp3s_iospec_bio3s_xover_core_guard(s IO_dp3s_state_
 }
 
 pred (dp DataPlaneSpec) dp3s_iospec_bio3s_xover_core(s IO_dp3s_state_local, t Place) {
-	forall v IO_val :: { dp.dp3s_iospec_bio3s_xover_core_guard(s, t, v) }{ CBio_IN_bio3s_xover_core(t, v) }{ dp.dp3s_iospec_ordered(dp3s_add_obuf(s, v.IO_Internal_val1_4, v.IO_Internal_val1_3), dp3s_iospec_bio3s_xover_core_T(t, v)) } (
+	forall v IO_val :: { TriggerBodyIoXoverCore(v) } (
 		match v {
-			case IO_Internal_val1{_, _, ?newpkt, ?nextif}: 
+			case IO_Internal_val1{_, _, ?newpkt, ?nextif}:
+				// Gobra requires the triggering term to occur inside the qtfier body,
+				// otherwise we get an error in the call to dp3s_iospec_bio3s_xover_core_T.
+				// We named the variable `_ignored` because using `_` here leads to a strange
+				// type error.
+				let _ignored := TriggerBodyIoXoverCore(v) in
 				(dp.Valid() && dp.dp3s_iospec_bio3s_xover_core_guard(s, t, v) ==>
-				(CBio_IN_bio3s_xover_core(t, v) &&
-				dp.dp3s_iospec_ordered(
-					dp3s_add_obuf(s, nextif, newpkt),
-					dp3s_iospec_bio3s_xover_core_T(t, v))))
-			default: 
+					(CBio_IN_bio3s_xover_core(t, v) &&
+					dp.dp3s_iospec_ordered(
+						dp3s_add_obuf(s, nextif, newpkt),
+						dp3s_iospec_bio3s_xover_core_T(t, v))))
+			default:
 				true
 		})
 }
+
+ghost
+decreases
+pure func TriggerBodyIoXoverCore(v IO_val) BogusTrigger { return BogusTrigger{} }
 
 pred CBio_IN_bio3s_exit(t Place, v IO_val)
 
@@ -265,19 +294,27 @@ pure func (dp DataPlaneSpec) dp3s_iospec_bio3s_exit_guard(s IO_dp3s_state_local,
 }
 
 pred (dp DataPlaneSpec) dp3s_iospec_bio3s_exit(s IO_dp3s_state_local, t Place) {
-	forall v IO_val :: { dp.dp3s_iospec_bio3s_exit_guard(s, t, v) }{ CBio_IN_bio3s_exit(t, v) }{ dp.dp3s_iospec_ordered(dp3s_add_obuf(s, some(v.IO_Internal_val2_3), v.IO_Internal_val2_2), dp3s_iospec_bio3s_exit_T(t, v)) } (
+	forall v IO_val :: { TriggerBodyIoExit(v) } (
 		match v {
-			case IO_Internal_val2{_, ?newpkt, ?nextif}: 
+			case IO_Internal_val2{_, ?newpkt, ?nextif}:
+				// Gobra requires the triggering term to occur inside the qtfier body,
+				// otherwise we get an error in the call to dp3s_iospec_bio3s_exit_T.
+				// We named the variable `_ignored` because using `_` here leads to a strange
+				// type error.
+				let _ignored := TriggerBodyIoExit(v) in
 				(dp.Valid() && dp.dp3s_iospec_bio3s_exit_guard(s, t, v) ==>
-				(CBio_IN_bio3s_exit(t, v) &&
-				dp.dp3s_iospec_ordered(
-					dp3s_add_obuf(s, some(nextif), newpkt),
-					dp3s_iospec_bio3s_exit_T(t, v))))
-			default: 
+					(CBio_IN_bio3s_exit(t, v) &&
+					dp.dp3s_iospec_ordered(
+						dp3s_add_obuf(s, some(nextif), newpkt),
+						dp3s_iospec_bio3s_exit_T(t, v))))
+			default:
 				true
-		})		
+		})
 }
 
+ghost
+decreases
+pure func TriggerBodyIoExit(v IO_val) BogusTrigger { return BogusTrigger{} }
 
 pred CBioIO_bio3s_send(t Place, v IO_val)
 
@@ -296,21 +333,34 @@ pure func (dp DataPlaneSpec) dp3s_iospec_bio3s_send_guard(s IO_dp3s_state_local,
 		(let obuf_set := s.obuf[v.IO_val_Pkt2_1] in (v.IO_val_Pkt2_2 in obuf_set))
 }
 
-// TODO: annotate WriteBatch, skipped for now
 pred (dp DataPlaneSpec) dp3s_iospec_bio3s_send(s IO_dp3s_state_local, t Place) {
-	forall v IO_val :: { dp.dp3s_iospec_bio3s_send_guard(s, t, v) }{ CBioIO_bio3s_send(t, v) }{ dp.dp3s_iospec_ordered(s, dp3s_iospec_bio3s_send_T(t, v)) }{ CBioIO_bio3s_send(t, v) }{ dp.dp3s_iospec_ordered(s, dp3s_iospec_bio3s_send_T(t, v)) } (
+	forall v IO_val :: { TriggerBodyIoSend(v) } (
 		match v {
-			case IO_val_Pkt2{_, _}: 
+			case IO_val_Pkt2{_, _}:
+				// Gobra requires the triggering term to occur inside the qtfier body,
+				// otherwise we get an error in the call to dp3s_iospec_bio3s_send_T.
+				// We named the variable `_ignored` because using `_` here leads to a strange
+				// type error.
+				let _ignored := TriggerBodyIoSend(v) in
 				(dp.Valid() && dp.dp3s_iospec_bio3s_send_guard(s, t, v) ==>
-				CBioIO_bio3s_send(t, v) &&
-				dp.dp3s_iospec_ordered(s, dp3s_iospec_bio3s_send_T(t, v)))
-			case IO_val_Unsupported{_, _}: 
+					CBioIO_bio3s_send(t, v) &&
+					dp.dp3s_iospec_ordered(s, dp3s_iospec_bio3s_send_T(t, v)))
+			case IO_val_Unsupported{_, _}:
+				// Gobra requires the triggering term to occur inside the qtfier body,
+				// otherwise we get an error in the call to dp3s_iospec_bio3s_send_T.
+				// We named the variable `_ignored` because using `_` here leads to a strange
+				// type error.
+				let _ignored := TriggerBodyIoSend(v) in
 				(CBioIO_bio3s_send(t, v) &&
 				dp.dp3s_iospec_ordered(s, dp3s_iospec_bio3s_send_T(t, v)))
-			default: 
+			default:
 				true
 		})
 }
+
+ghost
+decreases
+pure func TriggerBodyIoSend(v IO_val) BogusTrigger { return BogusTrigger{} }
 
 pred CBioIO_bio3s_recv(t Place)
 
@@ -319,7 +369,7 @@ requires CBioIO_bio3s_recv(t)
 decreases
 pure func dp3s_iospec_bio3s_recv_T(t Place) Place
 
-// We can safely make this assumption as Isabelle's IO-spec never 
+// We can safely make this assumption as Isabelle's IO-spec never
 // receives the other IO values (Unit and Internal).
 ghost
 requires CBioIO_bio3s_recv(t)
@@ -330,12 +380,12 @@ pure func dp3s_iospec_bio3s_recv_R(t Place) (val IO_val)
 pred (dp DataPlaneSpec) dp3s_iospec_bio3s_recv(s IO_dp3s_state_local, t Place) {
 	CBioIO_bio3s_recv(t) &&
 		(match dp3s_iospec_bio3s_recv_R(t) {
-			case IO_val_Pkt2{?recvif, ?pkt}: 
+			case IO_val_Pkt2{?recvif, ?pkt}:
 				dp.dp3s_iospec_ordered(
 					dp3s_add_ibuf(s, recvif, pkt), dp3s_iospec_bio3s_recv_T(t))
-			case IO_val_Unsupported{_, _}: 
+			case IO_val_Unsupported{_, _}:
 				dp.dp3s_iospec_ordered(s, dp3s_iospec_bio3s_recv_T(t))
-			default: 
+			default:
 				dp.dp3s_iospec_ordered(undefined(), dp3s_iospec_bio3s_recv_T(t))
 		})
 }
@@ -359,31 +409,31 @@ pred (dp DataPlaneSpec) dp3s_iospec_stop(s IO_dp3s_state_local, t Place) {
 ghost
 decreases
 requires token(t) && CBio_IN_bio3s_enter(t, v)
-ensures  token(old(CBio_IN_bio3s_enter_T(t, v))) 
+ensures  token(old(CBio_IN_bio3s_enter_T(t, v)))
 func Enter(ghost t Place, ghost v IO_val)
 
 ghost
 decreases
 requires token(t) && CBio_IN_bio3s_xover_core(t, v)
-ensures  token(old(dp3s_iospec_bio3s_xover_core_T(t, v))) 
+ensures  token(old(dp3s_iospec_bio3s_xover_core_T(t, v)))
 func Xover_core(ghost t Place, ghost v IO_val)
 
 ghost
 decreases
 requires token(t) && CBio_IN_bio3s_xover_up2down(t, v)
-ensures  token(old(dp3s_iospec_bio3s_xover_up2down_T(t, v))) 
+ensures  token(old(dp3s_iospec_bio3s_xover_up2down_T(t, v)))
 func Xover_up2down(ghost t Place, ghost v IO_val)
 
 ghost
 decreases
 requires token(t) && CBio_IN_bio3s_exit(t, v)
-ensures  token(old(dp3s_iospec_bio3s_exit_T(t, v))) 
+ensures  token(old(dp3s_iospec_bio3s_exit_T(t, v)))
 func Exit(ghost t Place, ghost v IO_val)
 
 ghost
 decreases
 requires token(t) && CBioIO_bio3s_send(t, v)
-ensures  token(old(dp3s_iospec_bio3s_send_T(t, v))) 
+ensures  token(old(dp3s_iospec_bio3s_send_T(t, v)))
 func Send(ghost t Place, ghost v IO_val)
 
 /** End of helper functions to perfrom BIO operations **/


### PR DESCRIPTION
This should improve performance, especially considering that triggers with resources tend to cause big slowdowns in Gobra/silicon. On the other hand, this requires slightly more annotations, as we need to explicitly trigger the bodies with calls to the `Trigger*` functions, e.g., `TriggerBodyIoEnter`.