### PR TITLE
Prove IO lemmas in `path/scion`

### DIFF
--- a/pkg/slayers/path/scion/base.go
+++ b/pkg/slayers/path/scion/base.go
@@ -242,18 +242,7 @@ type MetaHdr struct {
 // @ preserves acc(m)
 // @ preserves acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R50)
 // @ ensures   (len(raw) >= MetaLen) == (e == nil)
-// @ ensures   e == nil ==> (
-// @ 	MetaLen <= len(raw)              &&
-// @ 	0 <= m.CurrINF && m.CurrINF <= 3 &&
-// @ 	0 <= m.CurrHF  && m.CurrHF < 64  &&
-// @ 	m.SegsInBounds() &&
-// @ 	let lenR := len(raw) in
-// @ 	let b0 := sl.GetByte(raw, 0, lenR, 0) in
-// @ 	let b1 := sl.GetByte(raw, 0, lenR, 1) in
-// @ 	let b2 := sl.GetByte(raw, 0, lenR, 2) in
-// @ 	let b3 := sl.GetByte(raw, 0, lenR, 3) in
-// @ 	let line := binary.BigEndian.Uint32Spec(b0, b1, b2, b3) in
-// @ 	DecodedFrom(line) == *m)
+// @ ensures   e == nil ==> m.DecodeFromBytesSpec(raw)
 // @ ensures   e != nil ==> e.ErrorMem()
 // @ decreases
 func (m *MetaHdr) DecodeFromBytes(raw []byte) (e error) {
@@ -283,16 +272,11 @@ func (m *MetaHdr) DecodeFromBytes(raw []byte) (e error) {
 // @ preserves acc(m, R50)
 // @ preserves sl.AbsSlice_Bytes(b, 0, len(b))
 // @ ensures   e == nil
-// @ ensures   let lenR := len(b)           in
-// @ 	let b0 := sl.GetByte(b, 0, lenR, 0) in
-// @ 	let b1 := sl.GetByte(b, 0, lenR, 1) in
-// @ 	let b2 := sl.GetByte(b, 0, lenR, 2) in
-// @ 	let b3 := sl.GetByte(b, 0, lenR, 3) in
-// @ 	let v  := m.SerializedToLine()      in
-// @ 	binary.BigEndian.PutUint32Spec(b0, b1, b2, b3, v)
+// @ ensures   m.SerializeToSpec(b)
 // @ decreases
 func (m *MetaHdr) SerializeTo(b []byte) (e error) {
 	if len(b) < MetaLen {
+		// @ Unreachable()
 		return serrors.New("buffer for MetaHdr too short", "expected", MetaLen, "actual", len(b))
 	}
 	line := uint32(m.CurrINF)<<30 | uint32(m.CurrHF&0x3F)<<24

--- a/pkg/slayers/path/scion/base_spec.gobra
+++ b/pkg/slayers/path/scion/base_spec.gobra
@@ -20,6 +20,8 @@ import (
 	"encoding/binary"
 	"github.com/scionproto/scion/pkg/slayers/path"
 	sl "github.com/scionproto/scion/verification/utils/slices"
+
+	. "github.com/scionproto/scion/verification/utils/definitions"
 )
 
 pred (b *Base) NonInitMem() {
@@ -280,6 +282,21 @@ pure func (s MetaHdr) EqAbsHeader(ub []byte) bool {
 	return MetaLen <= len(ub) &&
 		unfolding acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), _) in
 		s == DecodedFrom(binary.BigEndian.Uint32(ub[:MetaLen]))
+}
+
+ghost
+opaque
+requires MetaLen <= idx && idx <= len(ub)
+requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), _)
+requires acc(sl.AbsSlice_Bytes(ub[:idx], 0, idx), _)
+ensures  s.EqAbsHeader(ub) == s.EqAbsHeader(ub[:idx])
+decreases
+pure func (s MetaHdr) EqAbsHeaderForSublice(ub []byte, idx int) Lemma {
+	return let _ := Asserting(ub[:MetaLen] === ub[:idx][:MetaLen]) in
+		unfolding acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), _) in
+		unfolding acc(sl.AbsSlice_Bytes(ub[:idx], 0, idx), _) in
+		let _ := Asserting(s.EqAbsHeader(ub) == (s == DecodedFrom(binary.BigEndian.Uint32(ub[:MetaLen])))) in
+		Lemma{}
 }
 
 /** Lemma proven in /VerifiedSCION/verification/utils/bitwise/proofs.dfy **/

--- a/pkg/slayers/path/scion/base_spec.gobra
+++ b/pkg/slayers/path/scion/base_spec.gobra
@@ -201,6 +201,23 @@ pure func DecodedFrom(line uint32) MetaHdr {
 }
 
 ghost
+requires acc(sl.AbsSlice_Bytes(b, 0, len(b)), _)
+decreases
+pure func (m MetaHdr) DecodeFromBytesSpec(b []byte) bool {
+	return MetaLen <= len(b)             &&
+		0 <= m.CurrINF && m.CurrINF <= 3 &&
+		0 <= m.CurrHF  && m.CurrHF < 64  &&
+		m.SegsInBounds() &&
+		let lenR := len(b) in
+		let b0 := sl.GetByte(b, 0, lenR, 0) in
+		let b1 := sl.GetByte(b, 0, lenR, 1) in
+		let b2 := sl.GetByte(b, 0, lenR, 2) in
+		let b3 := sl.GetByte(b, 0, lenR, 3) in
+		let line := binary.BigEndian.Uint32Spec(b0, b1, b2, b3) in
+		DecodedFrom(line) == m
+}
+
+ghost
 decreases
 pure func (m MetaHdr) SegsInBounds() bool {
 	return 0 <= m.SegLen[0] && m.SegLen[0] <= 63 &&
@@ -219,6 +236,20 @@ pure func (m MetaHdr) SerializedToLine() uint32 {
 }
 
 ghost
+requires acc(sl.AbsSlice_Bytes(b, 0, len(b)), _)
+decreases
+pure func (m MetaHdr) SerializeToSpec(b []byte) bool {
+	return MetaLen <= len(b)                &&
+		let lenR := len(b)                  in
+		let b0 := sl.GetByte(b, 0, lenR, 0) in
+		let b1 := sl.GetByte(b, 0, lenR, 1) in
+		let b2 := sl.GetByte(b, 0, lenR, 2) in
+		let b3 := sl.GetByte(b, 0, lenR, 3) in
+		let v  := m.SerializedToLine()      in
+		binary.BigEndian.PutUint32Spec(b0, b1, b2, b3, v)
+}
+
+ghost
 decreases
 pure func (m MetaHdr) InBounds() bool {
 	return 0 <= m.CurrINF && m.CurrINF <= 3   &&
@@ -233,9 +264,22 @@ requires acc(s.Mem(), _)
 requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), _)
 decreases
 pure func (s *Base) EQAbsHeader(ub []byte) bool {
+	// we compute the sublice ub[:MetaLen] inside this function instead
+	// of expecting the correct subslice to be passed, otherwise this function
+	// becomes too cumbersome to use in calls from (*Raw).EQAbsHeader due to the
+	// lack of a folding expression. Same goes for MetaHdr.EqAbsHeader.
 	return MetaLen <= len(ub) &&
 		unfolding acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), _) in
 		s.GetMetaHdr() == DecodedFrom(binary.BigEndian.Uint32(ub[:MetaLen]))
+}
+
+ghost
+requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), _)
+decreases
+pure func (s MetaHdr) EqAbsHeader(ub []byte) bool {
+	return MetaLen <= len(ub) &&
+		unfolding acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), _) in
+		s == DecodedFrom(binary.BigEndian.Uint32(ub[:MetaLen]))
 }
 
 /** Lemma proven in /VerifiedSCION/verification/utils/bitwise/proofs.dfy **/

--- a/pkg/slayers/path/scion/raw.go
+++ b/pkg/slayers/path/scion/raw.go
@@ -225,7 +225,7 @@ func (s *Raw) ToDecoded( /*@ ghost ubuf []byte @*/ ) (d *Decoded, err error) {
 // @ ensures  old(unfolding s.Mem(ubuf) in unfolding
 // @   s.Base.Mem() in (s.NumINF <= 0 || int(s.PathMeta.CurrHF) >= s.NumHops-1)) ==> r != nil
 // @ ensures  r == nil ==> s.Mem(ubuf)
-// @ ensures  r == nil ==> s.EQAbsHeader(ubuf)
+// @ ensures  r == nil && s.InBounds(ubuf) ==> s.EQAbsHeader(ubuf)
 // @ ensures  r != nil ==> s.NonInitMem()
 // @ ensures  r != nil ==> r.ErrorMem()
 // @ decreases

--- a/pkg/slayers/path/scion/raw.go
+++ b/pkg/slayers/path/scion/raw.go
@@ -221,7 +221,6 @@ func (s *Raw) ToDecoded( /*@ ghost ubuf []byte @*/ ) (d *Decoded, err error) {
 // @ requires sl.AbsSlice_Bytes(ubuf, 0, len(ubuf))
 // @ requires s.EQAbsHeader(ubuf)
 // @ ensures  sl.AbsSlice_Bytes(ubuf, 0, len(ubuf))
-// TODO: redo this post
 // @ ensures  old(unfolding s.Mem(ubuf) in unfolding
 // @   s.Base.Mem() in (s.NumINF <= 0 || int(s.PathMeta.CurrHF) >= s.NumHops-1)) ==> r != nil
 // @ ensures  r == nil ==> s.Mem(ubuf)
@@ -256,11 +255,10 @@ func (s *Raw) IncPath( /*@ ghost ubuf []byte @*/ ) (r error) {
 	//@ sl.Unslice_Bytes(ubuf, 0, MetaLen, R2)
 	//@ sl.CombineAtIndex_Bytes(ubuf, 0, len(ubuf), MetaLen, R2)
 	//@ fold acc(s.Mem(ubuf), R2)
-	//@ assert s.InBounds(ubuf) ==
-	//@ 	unfolding acc(s.Base.Mem(), _) in s.PathMeta.InBounds()
-	//@ assert s.EQAbsHeader(ubuf) ==
-	//@ 	unfolding acc(s.Base.Mem(), _) in s.PathMeta.EqAbsHeader(ubuf)
-	//@ assert s.PathMeta.InBounds() ==> s.PathMeta.EqAbsHeader(s.Raw[:MetaLen])
+	//@ assert s.InBounds(ubuf) == s.PathMeta.InBounds()
+	//@ assert s.EQAbsHeader(ubuf) == s.PathMeta.EqAbsHeader(ubuf)
+	//@ s.PathMeta.EqAbsHeaderForSublice(ubuf, MetaLen)
+	//@ assert s.EQAbsHeader(ubuf) == s.PathMeta.EqAbsHeader(s.Raw[:MetaLen])
 	//@ assert s.InBounds(ubuf) ==> s.EQAbsHeader(ubuf)
 
 	//@ sl.Unslice_Bytes(ubuf, 0, MetaLen, 1-R2)

--- a/pkg/slayers/path/scion/raw.go
+++ b/pkg/slayers/path/scion/raw.go
@@ -218,8 +218,10 @@ func (s *Raw) ToDecoded( /*@ ghost ubuf []byte @*/ ) (d *Decoded, err error) {
 
 // IncPath increments the path and writes it to the buffer.
 // @ requires s.Mem(ubuf)
+// @ requires sl.AbsSlice_Bytes(ubuf, 0, len(ubuf))
 // @ requires s.EQAbsHeader(ubuf)
-// @ preserves sl.AbsSlice_Bytes(ubuf, 0, len(ubuf))
+// @ ensures  sl.AbsSlice_Bytes(ubuf, 0, len(ubuf))
+// TODO: redo this post
 // @ ensures  old(unfolding s.Mem(ubuf) in unfolding
 // @   s.Base.Mem() in (s.NumINF <= 0 || int(s.PathMeta.CurrHF) >= s.NumHops-1)) ==> r != nil
 // @ ensures  r == nil ==> s.Mem(ubuf)
@@ -233,13 +235,39 @@ func (s *Raw) IncPath( /*@ ghost ubuf []byte @*/ ) (r error) {
 		//@ fold s.NonInitMem()
 		return err
 	}
-	//@ fold s.Mem(ubuf)
-	//@ s.RawIdxPerm(ubuf, MetaLen, writePerm)
-	//@ unfold acc(s.Base.Mem(), 1/2)
+	//@ sl.SplitByIndex_Bytes(ubuf, 0, len(ubuf), MetaLen, HalfPerm)
+	//@ sl.SplitByIndex_Bytes(ubuf, 0, len(ubuf), MetaLen, HalfPerm)
+	//@ sl.Reslice_Bytes(ubuf, 0, MetaLen, HalfPerm)
+	//@ sl.Reslice_Bytes(ubuf, 0, MetaLen, HalfPerm)
+
+	//@ unfold acc(s.Base.Mem(), R2)
 	err := s.PathMeta.SerializeTo(s.Raw[:MetaLen])
-	//@ fold acc(s.Base.Mem(), 1/2)
-	//@ s.UndoRawIdxPerm(ubuf, MetaLen, writePerm)
-	//@ assume s.EQAbsHeader(ubuf)
+	//@ ghost if s.PathMeta.InBounds() {
+	//@ 	v := s.Raw[:MetaLen]
+	//@ 	b0 := sl.GetByte(v, 0, MetaLen, 0)
+	//@ 	b1 := sl.GetByte(v, 0, MetaLen, 1)
+	//@ 	b2 := sl.GetByte(v, 0, MetaLen, 2)
+	//@ 	b3 := sl.GetByte(v, 0, MetaLen, 3)
+	//@ 	s.PathMeta.SerializeAndDeserializeLemma(b0, b1, b2, b3)
+	//@ }
+	//@ assert s.PathMeta.InBounds() ==> s.PathMeta.EqAbsHeader(s.Raw[:MetaLen])
+	//@ fold acc(s.Base.Mem(), R3)
+
+	//@ sl.Unslice_Bytes(ubuf, 0, MetaLen, R2)
+	//@ sl.CombineAtIndex_Bytes(ubuf, 0, len(ubuf), MetaLen, R2)
+	//@ fold acc(s.Mem(ubuf), R2)
+	//@ assert s.InBounds(ubuf) ==
+	//@ 	unfolding acc(s.Base.Mem(), _) in s.PathMeta.InBounds()
+	//@ assert s.EQAbsHeader(ubuf) ==
+	//@ 	unfolding acc(s.Base.Mem(), _) in s.PathMeta.EqAbsHeader(ubuf)
+	//@ assert s.PathMeta.InBounds() ==> s.PathMeta.EqAbsHeader(s.Raw[:MetaLen])
+	//@ assert s.InBounds(ubuf) ==> s.EQAbsHeader(ubuf)
+
+	//@ sl.Unslice_Bytes(ubuf, 0, MetaLen, 1-R2)
+	//@ sl.CombineAtIndex_Bytes(ubuf, 0, len(ubuf), MetaLen, 1-R2)
+	//@ fold acc(s.Base.Mem(), R3)
+	//@ fold acc(s.Mem(ubuf), 1-R2)
+	//@ assert s.InBounds(ubuf) ==> s.EQAbsHeader(ubuf)
 	return err
 }
 

--- a/pkg/slayers/path/scion/raw_spec.gobra
+++ b/pkg/slayers/path/scion/raw_spec.gobra
@@ -141,6 +141,15 @@ pure func (s *Raw) GetIsXoverSpec(ub []byte) bool {
 	return unfolding acc(s.Mem(ub), _) in s.Base.IsXoverSpec()
 }
 
+ghost
+requires acc(s.Mem(ub), _)
+decreases
+pure func (s *Raw) InBounds(ub []byte) bool {
+	return unfolding acc(s.Mem(ub), _) in
+		unfolding acc(s.Base.Mem(), _) in
+		s.PathMeta.InBounds()
+}
+
 /**** End of Stubs ****/
 
 /**** Lemmas ****/
@@ -199,52 +208,6 @@ func (r *Raw) RawPerm(ubuf []byte, p perm) {
 	fold r.RawPermRemainder(ubuf, p)
 }
 /******** End of Lemma: RawPerm ********/
-
-/******** Lemma: RawIdxPerm ********/
-pred (r *Raw) RawIdxPermRemainder(ubuf []byte, idx int, p perm) {
-	0 < p &&
-	acc(r.Base.Mem(), p/2) &&
-	acc(&r.Raw, p/2) &&
-	len(r.Raw) <= len(ubuf) &&
-	r.Raw === ubuf[:len(r.Raw)] &&
-	acc(sl.AbsSlice_Bytes(ubuf, idx, len(ubuf)), p) &&
-	len(r.Raw) == r.Base.Len() &&
-	idx <= len(r.Raw)
-}
-
-ghost
-requires 0 < p
-requires acc(&r.Raw, p/2)
-requires 0 <= idx && idx <= len(r.Raw)
-requires acc(sl.AbsSlice_Bytes(r.Raw[:idx], 0, idx), p) && acc(r.Base.Mem(), p/2)
-requires r.RawIdxPermRemainder(ubuf, idx, p)
-ensures  acc(r.Mem(ubuf), p)
-ensures  acc(sl.AbsSlice_Bytes(ubuf, 0, len(ubuf)), p)
-decreases
-func (r *Raw) UndoRawIdxPerm(ubuf []byte, idx int, p perm) {
-	unfold r.RawIdxPermRemainder(ubuf, idx, p)
-	sl.Unslice_Bytes(ubuf, 0, idx, p)
-	sl.CombineAtIndex_Bytes(ubuf, 0, len(ubuf), idx, p)
-	fold acc(r.Mem(ubuf), p)
-}
-
-ghost
-requires 0 < p
-requires acc(r.Mem(ubuf), p)
-requires acc(sl.AbsSlice_Bytes(ubuf, 0, len(ubuf)), p)
-requires 0 <= idx && idx <= unfolding acc(r.Mem(ubuf), p) in len(r.Raw)
-ensures  acc(&r.Raw, p/2)
-ensures  r.Raw === old(unfolding acc(r.Mem(ubuf), p) in r.Raw)
-ensures  acc(sl.AbsSlice_Bytes(r.Raw[:idx], 0, idx), p) && acc(r.Base.Mem(), p/2)
-ensures  r.RawIdxPermRemainder(ubuf, idx, p)
-decreases
-func (r *Raw) RawIdxPerm(ubuf []byte, idx int, p perm) {
-	unfold acc(r.Mem(ubuf), p)
-	sl.SplitByIndex_Bytes(ubuf, 0, len(ubuf), idx, p)
-	sl.Reslice_Bytes(ubuf, 0, idx, p)
-	fold r.RawIdxPermRemainder(ubuf, idx, p)
-}
-/******** End of Lemma: RawIdxPerm ********/
 
 /******** Lemma: RawRangePerm ********/
 pred (r *Raw) RawRangePermRemainder(ubuf []byte, start, end int, p perm) {

--- a/pkg/slayers/scion_spec.gobra
+++ b/pkg/slayers/scion_spec.gobra
@@ -354,10 +354,15 @@ opaque
 pure
 requires acc(s.Mem(ub), _)
 requires acc(slices.AbsSlice_Bytes(ub, 0, len(ub)), _)
+requires let ubPath := s.UBPath(ub) in
+	acc(slices.AbsSlice_Bytes(ubPath, 0, len(ubPath)), _)
 decreases
 func (s *SCION) EQAbsHeader(ub []byte) bool {
 	return unfolding acc(s.Mem(ub), _) in
 		GetAddressOffset(ub) == CmnHdrLen+s.AddrHdrLenSpecInternal() &&
+		// Might be worth introducing EQAbsHeader as an interface method on Path
+		// to avoid doing these casts, especially when we add support for EPIC.
+		typeOf(s.Path) == (*scion.Raw)                               &&
 		s.Path.(*scion.Raw).EQAbsHeader(ub[CmnHdrLen+s.AddrHdrLenSpecInternal() : s.HdrLen*LineLen])
 }
 

--- a/verification/utils/bitwise/proofs.dfy
+++ b/verification/utils/bitwise/proofs.dfy
@@ -101,3 +101,8 @@ lemma SerializeAndDeserializeLemma(m: MetaHdr, b0: bv8, b1: bv8, b2: bv8, b3: bv
 	ensures var line := SerializedToLine(m);
 		PutUint32Spec(b0, b1, b2, b3, line) ==> (DecodedFrom(Uint32Spec(b0, b1, b2, b3)) == m)
 {}
+
+lemma SerializeAndDeserializeMetaHdrLemma(m: MetaHdr)
+	requires InBounds(m)
+	ensures  DecodedFrom(SerializedToLine(m)) == m
+{}

--- a/verification/utils/definitions/definitions.gobra
+++ b/verification/utils/definitions/definitions.gobra
@@ -121,3 +121,5 @@ decreases
 func Asserting(ghost b bool) bool {
 	return true
 }
+
+type Lemma struct{}


### PR DESCRIPTION
This PR proves a few lemma in the `path/scion` package and performs some clean-up: we introduce `DecodeFromSpec` and `SerializeToSpec` for shortening specifications and allowing re-use and we drop the lemma `RawIdxPerm`. Even though this was useful in previous versions of silicon to keep verification time low, this is no longer necessary and this lemma is non-versatile: small changes to the call-place may require significant changes to the lemma