### PR TITLE
Update IO-spec to drop the `xover_core` event

### DIFF
--- a/router/io-spec-abstract-transitions.gobra
+++ b/router/io-spec-abstract-transitions.gobra
@@ -116,8 +116,8 @@ pure func AbsValidateEgressIDConstraintXover(pkt io.IO_pkt2, dp io.DataPlaneSpec
 	return let currseg := pkt.CurrSeg in
 		let rightseg := get(pkt.RightSeg) in
 		let nextIf := (currseg.ConsDir ? currseg.Future[0].EgIF2 : currseg.Future[0].InIF2) in
-		(dp.xover_up2down2_link_type_dir(dp.Asid(), rightseg.ConsDir, rightseg.Past[0],
-			currseg.ConsDir, currseg.Future[0])) &&
+		dp.xover_up2down2_link_type_dir(dp.Asid(), rightseg.ConsDir, rightseg.Past[0],
+			currseg.ConsDir, currseg.Future[0]) &&
 		nextIf != none[io.IO_ifs] &&
 		(get(nextIf) in domain(dp.GetNeighborIAs()))
 }

--- a/router/io-spec-abstract-transitions.gobra
+++ b/router/io-spec-abstract-transitions.gobra
@@ -114,9 +114,10 @@ requires  len(get(pkt.RightSeg).Past) > 0
 decreases
 pure func AbsValidateEgressIDConstraintXover(pkt io.IO_pkt2, dp io.DataPlaneSpec) bool {
 	return let currseg := pkt.CurrSeg in
+		let rightseg := get(pkt.RightSeg) in
 		let nextIf := (currseg.ConsDir ? currseg.Future[0].EgIF2 : currseg.Future[0].InIF2) in
-		((!get(pkt.RightSeg).ConsDir && pkt.CurrSeg.ConsDir) ==> dp.xover_up2down2_link_type(dp.Asid(), get(pkt.RightSeg).Past[0], pkt.CurrSeg.Future[0])) &&
-		((get(pkt.RightSeg).ConsDir == pkt.CurrSeg.ConsDir) ==> dp.xover_core2_link_type(get(pkt.RightSeg).Past[0], pkt.CurrSeg.Future[0], dp.Asid(), get(pkt.RightSeg).ConsDir)) &&
+		(dp.xover_up2down2_link_type_dir(dp.Asid(), rightseg.ConsDir, rightseg.Past[0],
+			currseg.ConsDir, currseg.Future[0])) &&
 		nextIf != none[io.IO_ifs] &&
 		(get(nextIf) in domain(dp.GetNeighborIAs()))
 }
@@ -204,7 +205,6 @@ ensures   dp.Valid()
 ensures   ElemWitness(ioSharedArg.OBufY, egressID, newPkt)
 decreases
 func XoverEvent(oldPkt io.IO_pkt2, ingressID option[io.IO_ifs], newPkt io.IO_pkt2, egressID option[io.IO_ifs], ioLock *sync.Mutex, ioSharedArg SharedArg, dp io.DataPlaneSpec) {
-	assume (!oldPkt.CurrSeg.ConsDir && newPkt.CurrSeg.ConsDir) || (oldPkt.CurrSeg.ConsDir == newPkt.CurrSeg.ConsDir)
 	reveal dp.Valid()
 	intermediatePkt1 := reveal AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
 	intermediatePkt2 := reveal AbsDoXover(intermediatePkt1)
@@ -216,11 +216,5 @@ func XoverEvent(oldPkt io.IO_pkt2, ingressID option[io.IO_ifs], newPkt io.IO_pkt
 	if(egressID != none[io.IO_ifs]){
 		reveal AbsProcessEgress(intermediatePkt2)
 	}
-	if(!oldPkt.CurrSeg.ConsDir && newPkt.CurrSeg.ConsDir) {
-		AtomicXoverUp2Down(oldPkt, ingressID, newPkt, egressID, ioLock, ioSharedArg, dp)
-	} else {
-		// TODO: How to deal with core?
-		assume dp.Asid() in dp.Core()
-		AtomicXoverCore(oldPkt, ingressID, newPkt, egressID, ioLock, ioSharedArg, dp)
-	}
+	AtomicXoverUp2Down(oldPkt, ingressID, newPkt, egressID, ioLock, ioSharedArg, dp)
 }

--- a/router/io-spec-atomic-events.gobra
+++ b/router/io-spec-atomic-events.gobra
@@ -123,91 +123,19 @@ func AtomicExit(oldPkt io.IO_pkt2, ingressID option[io.IO_ifs], newPkt io.IO_pkt
 	ghost ioLock.Unlock()
 }
 
-
-// TODO: add comment why terminations is assumed
-ghost
-requires  dp.Valid()
-requires  dp.Asid() in dp.Core()
-requires  oldPkt.LeftSeg != none[io.IO_seg2]
-requires  oldPkt.CurrSeg.ConsDir == get(oldPkt.LeftSeg).ConsDir
-requires  len(oldPkt.CurrSeg.Future) > 0
-requires  len(get(oldPkt.LeftSeg).Future) > 0
-requires  ingressID != none[io.IO_ifs]
-requires  ElemWitness(ioSharedArg.IBufY, ingressID, oldPkt)
-requires  dp.xover_core2_link_type(
-	oldPkt.CurrSeg.Future[0],
-	get(oldPkt.LeftSeg).Future[0],
-	dp.Asid(),
-	oldPkt.CurrSeg.ConsDir)
-requires  dp.dp2_xover_common_guard(
-	oldPkt,
-	oldPkt.CurrSeg,
-	get(oldPkt.LeftSeg),
-	io.establishGuardTraversedsegInc(oldPkt.CurrSeg, !oldPkt.CurrSeg.ConsDir),
-	io.IO_pkt2(io.IO_Packet2{
-		get(oldPkt.LeftSeg),
-		oldPkt.MidSeg,
-		oldPkt.RightSeg,
-		some(io.establishGuardTraversedsegInc(oldPkt.CurrSeg, !oldPkt.CurrSeg.ConsDir))}),
-	oldPkt.CurrSeg.Future[0],
-	get(oldPkt.LeftSeg).Future[0],
-	dp.Asid(),
-	get(ingressID))
-requires  dp.dp3s_forward_xover(
-	io.IO_pkt2(io.IO_Packet2{
-		get(oldPkt.LeftSeg),
-		oldPkt.MidSeg,
-		oldPkt.RightSeg,
-		some(io.establishGuardTraversedsegInc(oldPkt.CurrSeg, !oldPkt.CurrSeg.ConsDir))}),
-	newPkt,
-	egressID)
-preserves acc(ioLock.LockP(), _) && ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>;
-ensures   ElemWitness(ioSharedArg.OBufY, egressID, newPkt)
-decreases _
-func AtomicXoverCore(oldPkt io.IO_pkt2, ingressID option[io.IO_ifs], newPkt io.IO_pkt2, egressID option[io.IO_ifs], ioLock *sync.Mutex, ioSharedArg SharedArg, dp io.DataPlaneSpec) {
-    ghost ioLock.Lock()
-	unfold SharedInv!< dp, ioSharedArg !>()
-
-	t, s := *ioSharedArg.Place, *ioSharedArg.State
-
-	ApplyElemWitness(s.ibuf, ioSharedArg.IBufY, ingressID, oldPkt)
-    ghost pkt_internal := io.IO_val(io.IO_Internal_val1{
-                oldPkt,
-                get(ingressID),
-                newPkt,
-                egressID})
-
-
-	assert dp.dp3s_iospec_bio3s_xover_core_guard(s, t, pkt_internal)
-	unfold dp.dp3s_iospec_ordered(s, t)
-	unfold dp.dp3s_iospec_bio3s_xover_core(s, t)
-	io.TriggerBodyIoXoverCore(pkt_internal)
-
-	tN := io.dp3s_iospec_bio3s_xover_core_T(t, pkt_internal)
-	io.Xover_core(t, pkt_internal) //Event
-
-	UpdateElemWitness(s.obuf, ioSharedArg.OBufY, egressID, newPkt)
-
-	ghost *ioSharedArg.State = io.dp3s_add_obuf(s, egressID, newPkt)
-	ghost *ioSharedArg.Place = tN
-
-	fold SharedInv!< dp, ioSharedArg !>()
-	ghost ioLock.Unlock()
-}
-
 // TODO: add comment why terminations is assumed
 ghost
 requires  dp.Valid()
 requires  oldPkt.LeftSeg != none[io.IO_seg2]
-requires  !oldPkt.CurrSeg.ConsDir
-requires  get(oldPkt.LeftSeg).ConsDir
 requires  len(oldPkt.CurrSeg.Future) > 0
 requires  len(get(oldPkt.LeftSeg).Future) > 0
 requires  ingressID != none[io.IO_ifs]
 requires  ElemWitness(ioSharedArg.IBufY, ingressID, oldPkt)
-requires  dp.xover_up2down2_link_type(
+requires  dp.xover_up2down2_link_type_dir(
 	dp.Asid(),
+	oldPkt.CurrSeg.ConsDir,
 	oldPkt.CurrSeg.Future[0],
+	get(oldPkt.LeftSeg).ConsDir,
 	get(oldPkt.LeftSeg).Future[0])
 requires  dp.dp2_xover_common_guard(
 	oldPkt,
@@ -221,6 +149,7 @@ requires  dp.dp2_xover_common_guard(
 		some(io.establishGuardTraversedsegInc(oldPkt.CurrSeg, !oldPkt.CurrSeg.ConsDir))}),
 	oldPkt.CurrSeg.Future[0],
 	get(oldPkt.LeftSeg).Future[0],
+	get(oldPkt.LeftSeg).Future[1:],
 	dp.Asid(),
 	get(ingressID))
 requires  dp.dp3s_forward_xover(

--- a/verification/io/bios.gobra
+++ b/verification/io/bios.gobra
@@ -21,7 +21,6 @@ package io
 type IO_bio3sIN adt {
 	IO_bio3s_enter{}
 	IO_bio3s_xover_up2down{}
-	IO_bio3s_xover_core{}
 	IO_bio3s_exit{}
 }
 

--- a/verification/io/io-spec.gobra
+++ b/verification/io/io-spec.gobra
@@ -29,7 +29,6 @@ type BogusTrigger struct{}
 pred (dp DataPlaneSpec) dp3s_iospec_ordered(s IO_dp3s_state_local, t Place) {
 	dp.dp3s_iospec_bio3s_enter(s, t) &&
 	dp.dp3s_iospec_bio3s_xover_up2down(s, t) &&
-	dp.dp3s_iospec_bio3s_xover_core(s, t) &&
 	dp.dp3s_iospec_bio3s_exit(s, t) &&
 	dp.dp3s_iospec_bio3s_send(s, t) &&
 	dp.dp3s_iospec_bio3s_recv(s, t) &&
@@ -163,13 +162,12 @@ pure func (dp DataPlaneSpec) dp3s_iospec_bio3s_xover_up2down_guard(s IO_dp3s_sta
 				false
 			default:
 				let nextseg := get(v.IO_Internal_val1_1.LeftSeg) in
-				(!currseg.ConsDir &&
-				nextseg.ConsDir &&
-				len(nextseg.Future) > 0 &&
+				(len(nextseg.Future) > 0 &&
 				len(currseg.Future) > 0 &&
 				let hf1, hf2 := currseg.Future[0], nextseg.Future[0] in
 				let traversedseg := establishGuardTraversedsegInc(currseg, !currseg.ConsDir) in
-				(dp.xover_up2down2_link_type(dp.Asid(), hf1, hf2) &&
+				let nextfut := nextseg.Future[1:] in
+				(dp.xover_up2down2_link_type_dir(dp.Asid(), currseg.ConsDir, hf1, nextseg.ConsDir, hf2) &&
 					dp.dp3s_xover_common(
 						s,
 						v.IO_Internal_val1_1,
@@ -179,6 +177,7 @@ pure func (dp DataPlaneSpec) dp3s_iospec_bio3s_xover_up2down_guard(s IO_dp3s_sta
 						IO_pkt2(IO_Packet2{nextseg, v.IO_Internal_val1_1.MidSeg, v.IO_Internal_val1_1.RightSeg, some(traversedseg)}),
 						hf1,
 						hf2,
+						nextfut,
 						v.IO_Internal_val1_2,
 						v.IO_Internal_val1_3,
 						v.IO_Internal_val1_4,)))
@@ -207,70 +206,6 @@ pred (dp DataPlaneSpec) dp3s_iospec_bio3s_xover_up2down(s IO_dp3s_state_local, t
 ghost
 decreases
 pure func TriggerBodyIoXoverUp2Down(v IO_val) BogusTrigger { return BogusTrigger{} }
-
-pred CBio_IN_bio3s_xover_core(t Place, v IO_val)
-
-ghost
-requires CBio_IN_bio3s_xover_core(t, v)
-decreases
-pure func dp3s_iospec_bio3s_xover_core_T(t Place, v IO_val) Place
-
-// This corresponds to the condition of the if statement in the io-spec case for xover_core
-ghost
-requires v.isIO_Internal_val1
-requires dp.Valid()
-decreases
-pure func (dp DataPlaneSpec) dp3s_iospec_bio3s_xover_core_guard(s IO_dp3s_state_local, t Place, v IO_val) bool {
-	return (dp.Asid() in dp.Core() &&
-		let currseg := v.IO_Internal_val1_1.CurrSeg in
-		match v.IO_Internal_val1_1.LeftSeg {
-			case none[IO_seg2]:
-				false
-			default:
-				let nextseg := get(v.IO_Internal_val1_1.LeftSeg) in
-				currseg.ConsDir == nextseg.ConsDir &&
-				len(nextseg.Future) > 0 &&
-				len(currseg.Future) > 0 &&
-				let hf1, hf2 := currseg.Future[0], nextseg.Future[0] in
-				let traversedseg := establishGuardTraversedsegInc(currseg, !currseg.ConsDir) in
-				(dp.xover_core2_link_type(hf1, hf2, dp.Asid(), currseg.ConsDir) &&
-					dp.dp3s_xover_common(
-						s,
-						v.IO_Internal_val1_1,
-						currseg,
-						nextseg,
-						traversedseg,
-						IO_pkt2(IO_Packet2{nextseg, v.IO_Internal_val1_1.MidSeg, v.IO_Internal_val1_1.RightSeg, some(traversedseg)}),
-						hf1,
-						hf2,
-						v.IO_Internal_val1_2,
-						v.IO_Internal_val1_3,
-						v.IO_Internal_val1_4))
-		})
-}
-
-pred (dp DataPlaneSpec) dp3s_iospec_bio3s_xover_core(s IO_dp3s_state_local, t Place) {
-	forall v IO_val :: { TriggerBodyIoXoverCore(v) } (
-		match v {
-			case IO_Internal_val1{_, _, ?newpkt, ?nextif}:
-				// Gobra requires the triggering term to occur inside the qtfier body,
-				// otherwise we get an error in the call to dp3s_iospec_bio3s_xover_core_T.
-				// We named the variable `_ignored` because using `_` here leads to a strange
-				// type error.
-				let _ignored := TriggerBodyIoXoverCore(v) in
-				(dp.Valid() && dp.dp3s_iospec_bio3s_xover_core_guard(s, t, v) ==>
-					(CBio_IN_bio3s_xover_core(t, v) &&
-					dp.dp3s_iospec_ordered(
-						dp3s_add_obuf(s, nextif, newpkt),
-						dp3s_iospec_bio3s_xover_core_T(t, v))))
-			default:
-				true
-		})
-}
-
-ghost
-decreases
-pure func TriggerBodyIoXoverCore(v IO_val) BogusTrigger { return BogusTrigger{} }
 
 pred CBio_IN_bio3s_exit(t Place, v IO_val)
 
@@ -409,12 +344,6 @@ decreases
 requires token(t) && CBio_IN_bio3s_enter(t, v)
 ensures  token(old(CBio_IN_bio3s_enter_T(t, v)))
 func Enter(ghost t Place, ghost v IO_val)
-
-ghost
-decreases
-requires token(t) && CBio_IN_bio3s_xover_core(t, v)
-ensures  token(old(dp3s_iospec_bio3s_xover_core_T(t, v)))
-func Xover_core(ghost t Place, ghost v IO_val)
 
 ghost
 decreases

--- a/verification/io/router.gobra
+++ b/verification/io/router.gobra
@@ -193,6 +193,7 @@ pure func (dp DataPlaneSpec) dp3s_xover_common(
 	intermediatepkt IO_pkt3,
 	hf1 IO_HF,
 	hf2 IO_HF,
+	nextfut seq[IO_HF],
 	recvif IO_ifs,
 	newpkt IO_pkt3,
 	nextif option[IO_ifs],
@@ -201,6 +202,6 @@ pure func (dp DataPlaneSpec) dp3s_xover_common(
 		// this is because of the way math. maps are implemented, we can only obtain a key that is in the map before.
 		return some(recvif) in domain(s.ibuf) &&
 			(let lookupRes := s.ibuf[some(recvif)] in (m in lookupRes)) &&
-			dp.dp2_xover_common_guard(m, currseg, nextseg, traversedseg, intermediatepkt, hf1, hf2, dp.Asid(), recvif) &&
+			dp.dp2_xover_common_guard(m, currseg, nextseg, traversedseg, intermediatepkt, hf1, hf2, nextfut, dp.Asid(), recvif) &&
 			dp.dp3s_forward_xover(intermediatepkt, newpkt, nextif)
 }

--- a/verification/io/router_events.gobra
+++ b/verification/io/router_events.gobra
@@ -18,16 +18,6 @@
 
 package io
 
-ghost
-requires dp.Valid()
-requires asid == dp.Asid()
-decreases
-pure func (dp DataPlaneSpec) dp2_check_recvif(d bool, asid IO_as, recvif IO_ifs) bool {
-	return d?
-		(dp.link_type(asid, recvif) == IO_CustProv{} || dp.link_type(asid, recvif) == IO_PeerOrCore{}) :
-		(dp.link_type(asid, recvif) == IO_ProvCust{} || dp.link_type(asid, recvif) == IO_PeerOrCore{})
-}
-
 /* Abbreviations */
 ghost
 requires dp.Valid()

--- a/verification/io/xover.gobra
+++ b/verification/io/xover.gobra
@@ -18,22 +18,18 @@
 
 package io
 
+// Switching between segments (xover)
 // Xover events are similar to the enter event in that a packet is received form an external
-// channel and forwarded (internally or externally), but in contrast to the enter event,
-// additional processing steps are required to switch from the current segment,
-// which has reached its end, to the next segment.
-// We have two events for xovering segments. One in which we xover from a segment against
-// construction direction to one in construction direction (up2down), and one in which we
-// xover between segments of the same directionality. The latter can only happen at a
-// core node, hence we call it “xover_core"
+// channel and forwarded (internally or externally), but in contrast to the enter event, additional
+// processing steps are required to switch from the current segment, which has reached its end, to the
+// next segment.
 
-// Common guard between"dp2_xover_up2down"and "dp2_xover_core":
-// Check if we are at the end of one segment and that there is a non empty
-// Future segment. There are three different segments in this definition:
-// currseg, the 'old segment' with exactly one hop field remaining in the
-// Future path, traversedseg, which is currseg after we push its
-// remaining hop field into the Past path, and nextseg, which is
-// the new segment that we are xovering over to.
+// Guard:
+// Check if we are at the end of one segment and that there is a non empty Future segment.
+// There are three different segments in this definition: currseg, the 'old segment' with
+// exactly one hop field remaining in the Future path, traversedseg, which is currseg after we
+// push its remaining hop field into the Past path, and nextseg, which is the new segment that we
+// are xovering over to
 ghost
 requires dp.Valid()
 requires asid == dp.Asid()
@@ -45,6 +41,7 @@ pure func (dp DataPlaneSpec) dp2_xover_common_guard(m IO_pkt2,
 	newpkt IO_pkt2,
 	hf1 IO_HF,
 	hf2 IO_HF,
+	nextfut seq[IO_HF],
 	asid IO_as,
 	recvif IO_ifs) bool {
 		return m.CurrSeg == currseg &&
@@ -52,8 +49,7 @@ pure func (dp DataPlaneSpec) dp2_xover_common_guard(m IO_pkt2,
 			nextseg.History == seq[IO_ahi]{} &&
 			newpkt == IO_pkt2(IO_Packet2{nextseg, m.MidSeg, m.RightSeg, some(traversedseg)}) &&
 			currseg.Future == seq[IO_HF]{hf1} &&
-			len(nextseg.Future) > 0 &&
-			nextseg.Future[0] == hf2 &&
+			nextseg.Future == seq[IO_HF]{hf2} ++ nextfut &&
 			dp.dp2_check_interface(currseg.ConsDir, asid, hf1, recvif) &&
 			dp.dp2_check_recvif(currseg.ConsDir, asid, recvif) &&
 			update_uinfo(!currseg.ConsDir, currseg, traversedseg, hf1) &&
@@ -86,16 +82,27 @@ requires dp.Valid()
 requires asid == dp.Asid()
 decreases
 pure func (dp DataPlaneSpec) xover_up2down2_link_type(asid IO_as, hf1 IO_HF, hf2 IO_HF) bool {
-	return (dp.egif2_type(hf1, asid, IO_ProvCust{}) && dp.egif2_type(hf2, asid, IO_ProvCust{})) ||
-		(dp.egif2_type(hf1, asid, IO_ProvCust{}) && dp.egif2_type(hf2, asid, IO_PeerOrCore{})) ||
-		(dp.egif2_type(hf1, asid, IO_PeerOrCore{}) && dp.egif2_type(hf2, asid, IO_ProvCust{}))
+	return (dp.inif2_type(hf1, asid, IO_ProvCust{}) && dp.egif2_type(hf2, asid, IO_ProvCust{})) ||
+		(dp.inif2_type(hf1, asid, IO_ProvCust{}) && dp.egif2_type(hf2, asid, IO_PeerOrCore{})) ||
+		(dp.inif2_type(hf1, asid, IO_PeerOrCore{}) && dp.egif2_type(hf2, asid, IO_ProvCust{}))
+}
+
+ghost
+decreases
+pure func swap_if_dir2(hf IO_HF, d bool) IO_HF {
+	return IO_HF(IO_HF_{
+			InIF2 : d ? hf.InIF2 : hf.EgIF2,
+			EgIF2 : d ? hf.EgIF2 : hf.InIF2,
+			HVF : hf.HVF,
+		})
 }
 
 ghost
 requires dp.Valid()
 requires asid == dp.Asid()
 decreases
-pure func (dp DataPlaneSpec) xover_core2_link_type(hf1 IO_HF, hf2 IO_HF, asid IO_as, d bool) bool {
-	return (!d && dp.egif2_type(hf1, asid, IO_ProvCust{}) && dp.inif2_type(hf2, asid, IO_PeerOrCore{})) ||
-		(d && dp.inif2_type(hf1, asid, IO_PeerOrCore{}) && dp.egif2_type(hf2, asid, IO_ProvCust{}))
+pure func (dp DataPlaneSpec) xover_up2down2_link_type_dir(asid IO_as, d1 bool, hf1 IO_HF, d2 bool, hf2 IO_HF) bool {
+	return dp.xover_up2down2_link_type(asid, swap_if_dir2(hf1, d1), swap_if_dir2(hf2, d2))
 }
+
+

--- a/verification/io/xover.gobra
+++ b/verification/io/xover.gobra
@@ -51,7 +51,6 @@ pure func (dp DataPlaneSpec) dp2_xover_common_guard(m IO_pkt2,
 			currseg.Future == seq[IO_HF]{hf1} &&
 			nextseg.Future == seq[IO_HF]{hf2} ++ nextfut &&
 			dp.dp2_check_interface(currseg.ConsDir, asid, hf1, recvif) &&
-			dp.dp2_check_recvif(currseg.ConsDir, asid, recvif) &&
 			update_uinfo(!currseg.ConsDir, currseg, traversedseg, hf1) &&
 			inc_seg2(currseg, traversedseg, hf1, seq[IO_HF]{}) &&
 			dp.hf_valid(currseg.ConsDir, currseg.AInfo, traversedseg.UInfo, hf1) &&


### PR DESCRIPTION
This PR updates the IO-spec to reflect the latest changes to the IO spec. In particular, the `xover_core` event is now completely dropped.