### PR TITLE
 IO-spec update for link check logic

### DIFF
--- a/pkg/slayers/path/scion/base_spec.gobra
+++ b/pkg/slayers/path/scion/base_spec.gobra
@@ -429,8 +429,8 @@ pure func (s MetaHdr) EqAbsHeader(ub []byte) bool {
 ghost
 opaque
 requires MetaLen <= idx && idx <= len(ub)
-requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R56)
-requires acc(sl.AbsSlice_Bytes(ub[:idx], 0, idx), R56)
+requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R55)
+requires acc(sl.AbsSlice_Bytes(ub[:idx], 0, idx), R55)
 ensures  s.EqAbsHeader(ub) == s.EqAbsHeader(ub[:idx])
 decreases
 pure func (s MetaHdr) EqAbsHeaderForSublice(ub []byte, idx int) Lemma {

--- a/pkg/slayers/path/scion/base_spec.gobra
+++ b/pkg/slayers/path/scion/base_spec.gobra
@@ -406,17 +406,15 @@ pure func (m MetaHdr) InBounds() bool {
 }
 
 ghost
-requires acc(s.Mem(), _)
-requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), _)
+requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R56)
 decreases
-pure func (s *Base) EqAbsHeader(ub []byte) bool {
+pure func (s Base) EqAbsHeader(ub []byte) bool {
 	// we compute the sublice ub[:MetaLen] inside this function instead
 	// of expecting the correct subslice to be passed, otherwise this function
 	// becomes too cumbersome to use in calls from (*Raw).EqAbsHeader due to the
 	// lack of a folding expression. Same goes for MetaHdr.EqAbsHeader.
 	return MetaLen <= len(ub) &&
-		unfolding acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), _) in
-		s.GetMetaHdr() == DecodedFrom(binary.BigEndian.Uint32(ub[:MetaLen]))
+		s == RawBytesToBase(ub)
 }
 
 ghost
@@ -431,14 +429,14 @@ pure func (s MetaHdr) EqAbsHeader(ub []byte) bool {
 ghost
 opaque
 requires MetaLen <= idx && idx <= len(ub)
-requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), _)
-requires acc(sl.AbsSlice_Bytes(ub[:idx], 0, idx), _)
+requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R56)
+requires acc(sl.AbsSlice_Bytes(ub[:idx], 0, idx), R56)
 ensures  s.EqAbsHeader(ub) == s.EqAbsHeader(ub[:idx])
 decreases
 pure func (s MetaHdr) EqAbsHeaderForSublice(ub []byte, idx int) Lemma {
 	return let _ := Asserting(ub[:MetaLen] === ub[:idx][:MetaLen]) in
-		unfolding acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), _) in
-		unfolding acc(sl.AbsSlice_Bytes(ub[:idx], 0, idx), _) in
+		unfolding acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R56) in
+		unfolding acc(sl.AbsSlice_Bytes(ub[:idx], 0, idx), R56) in
 		let _ := Asserting(s.EqAbsHeader(ub) == (s == DecodedFrom(binary.BigEndian.Uint32(ub[:MetaLen])))) in
 		Lemma{}
 }

--- a/pkg/slayers/path/scion/raw.go
+++ b/pkg/slayers/path/scion/raw.go
@@ -481,12 +481,13 @@ func (s *Raw) IsPenultimateHop( /*@ ghost ubuf []byte @*/ ) bool {
 }
 
 // IsLastHop returns whether the current hop is the last hop on the path.
-// @ preserves acc(s.Mem(ubuf), R20)
+// @ preserves acc(s.Mem(ubuf), R40)
+// @ ensures res == s.IsLastHopSpec(ubuf)
 // @ decreases
-func (s *Raw) IsLastHop( /*@ ghost ubuf []byte @*/ ) bool {
-	//@ unfold acc(s.Mem(ubuf), R20)
-	//@ defer  fold acc(s.Mem(ubuf), R20)
-	//@ unfold acc(s.Base.Mem(), R20)
-	//@ defer  fold acc(s.Base.Mem(), R20)
+func (s *Raw) IsLastHop( /*@ ghost ubuf []byte @*/ ) /*@ (res @*/ bool /* @ ) @*/ {
+	//@ unfold acc(s.Mem(ubuf), R40)
+	//@ defer  fold acc(s.Mem(ubuf), R40)
+	//@ unfold acc(s.Base.Mem(), R40)
+	//@ defer  fold acc(s.Base.Mem(), R40)
 	return int(s.PathMeta.CurrHF) == (s.NumHops - 1)
 }

--- a/pkg/slayers/path/scion/raw.go
+++ b/pkg/slayers/path/scion/raw.go
@@ -484,7 +484,7 @@ func (s *Raw) IsPenultimateHop( /*@ ghost ubuf []byte @*/ ) bool {
 // @ preserves acc(s.Mem(ubuf), R40)
 // @ ensures res == s.IsLastHopSpec(ubuf)
 // @ decreases
-func (s *Raw) IsLastHop( /*@ ghost ubuf []byte @*/ ) /*@ (res @*/ bool /* @ ) @*/ {
+func (s *Raw) IsLastHop( /*@ ghost ubuf []byte @*/ ) (res bool) {
 	//@ unfold acc(s.Mem(ubuf), R40)
 	//@ defer  fold acc(s.Mem(ubuf), R40)
 	//@ unfold acc(s.Base.Mem(), R40)

--- a/pkg/slayers/path/scion/raw_spec.gobra
+++ b/pkg/slayers/path/scion/raw_spec.gobra
@@ -127,10 +127,11 @@ pure func (s *Raw) ValidCurrIdxs(ghost ub []byte) bool {
 
 ghost
 requires acc(s.Mem(ub), _)
-requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), _)
+requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R56)
 decreases
 pure func (s *Raw) EqAbsHeader(ub []byte) bool {
 	return unfolding acc(s.Mem(ub), _) in
+		unfolding acc(s.Base.Mem(), _) in
 		s.Base.EqAbsHeader(ub)
 }
 
@@ -629,4 +630,41 @@ pure func AbsSetInfoField(oldPkt io.IO_pkt2, info path.IntermediateAbsInfoField)
 		oldPkt.CurrSeg.Future,
 		oldPkt.CurrSeg.History}) in
 	io.IO_pkt2(io.IO_Packet2{newCurrSeg, oldPkt.LeftSeg, oldPkt.MidSeg, oldPkt.RightSeg})
+}
+
+ghost
+requires acc(s.Mem(ub), _)
+decreases
+pure func (s *Raw) IsLastHopSpec(ub []byte) bool {
+	return unfolding acc(s.Mem(ub), _) in
+		unfolding acc(s.Base.Mem(), _) in
+		int(s.PathMeta.CurrHF) == (s.NumHops - 1)
+}
+
+ghost
+preserves acc(s.Mem(ubuf), R55)
+preserves s.IsLastHopSpec(ubuf)
+preserves acc(sl.AbsSlice_Bytes(ubuf, 0, len(ubuf)), R56)
+preserves dp.Valid()
+preserves validPktMetaHdr(ubuf)
+preserves s.EqAbsHeader(ubuf)
+ensures len(s.absPkt(dp, ubuf).CurrSeg.Future) == 1
+decreases
+func (s *Raw) LastHopLemma(ubuf []byte, dp io.DataPlaneSpec) {
+	reveal validPktMetaHdr(ubuf)
+	hdr := (unfolding acc(sl.AbsSlice_Bytes(ubuf, 0, len(ubuf)), R56) in
+			binary.BigEndian.Uint32(ubuf[:MetaLen]))
+	metaHdr := DecodedFrom(hdr)
+	currINFIdx := int(metaHdr.CurrINF)
+	currHFIdx := int(metaHdr.CurrHF)
+	seg1Len := int(metaHdr.SegLen[0])
+	seg2Len := int(metaHdr.SegLen[1])
+	seg3Len := int(metaHdr.SegLen[2])
+	segLen := LengthOfCurrSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
+	prevSegLen := LengthOfPrevSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
+	numINF := NumInfoFields(seg1Len, seg2Len, seg3Len)
+	offset := HopFieldOffset(numINF, 0, 0)
+	pkt := reveal s.absPkt(dp, ubuf)
+	assert pkt.CurrSeg == reveal CurrSeg(ubuf, offset+prevSegLen, currINFIdx, currHFIdx-prevSegLen, segLen, 0)
+	assert len(pkt.CurrSeg.Future) == 1
 }

--- a/router/io-spec-abstract-transitions.gobra
+++ b/router/io-spec-abstract-transitions.gobra
@@ -52,6 +52,17 @@ pure func AbsValidateIngressIDConstraint(pkt io.IO_pkt2, ingressID option[io.IO_
 
 ghost
 opaque
+requires pkt.RightSeg != none[io.IO_seg2]
+requires len(get(pkt.RightSeg).Past) > 0
+decreases
+pure func AbsValidateIngressIDConstraintXover(pkt io.IO_pkt2, ingressID option[io.IO_ifs]) bool {
+	return let rightseg := get(pkt.RightSeg) in
+		ingressID != none[io.IO_ifs] ==>
+			ingressID == (rightseg.ConsDir ? rightseg.Past[0].InIF2 : rightseg.Past[0].EgIF2)
+}
+
+ghost
+opaque
 requires len(pkt.CurrSeg.Future) > 0
 decreases
 pure func AbsEgressInterfaceConstraint(pkt io.IO_pkt2, egressID option[io.IO_ifs]) bool {
@@ -67,7 +78,7 @@ decreases
 pure func AbsValidateEgressIDConstraint(pkt io.IO_pkt2, enter bool, dp io.DataPlaneSpec) bool {
 	return let currseg := pkt.CurrSeg in
 		let nextIf := (currseg.ConsDir ? currseg.Future[0].EgIF2 : currseg.Future[0].InIF2) in
-		dp.dp2_check_interface_top(currseg.ConsDir, dp.Asid(), currseg.Future[0]) &&
+		(enter ==> dp.dp2_check_interface_top(currseg.ConsDir, dp.Asid(), currseg.Future[0])) &&
 		nextIf != none[io.IO_ifs] &&
 		(get(nextIf) in domain(dp.GetNeighborIAs()))
 }
@@ -117,9 +128,9 @@ pure func AbsValidateEgressIDConstraintXover(pkt io.IO_pkt2, dp io.DataPlaneSpec
 		let rightseg := get(pkt.RightSeg) in
 		let nextIf := (currseg.ConsDir ? currseg.Future[0].EgIF2 : currseg.Future[0].InIF2) in
 		dp.xover_up2down2_link_type_dir(dp.Asid(), rightseg.ConsDir, rightseg.Past[0],
-			currseg.ConsDir, currseg.Future[0]) &&
-		nextIf != none[io.IO_ifs] &&
-		(get(nextIf) in domain(dp.GetNeighborIAs()))
+			currseg.ConsDir, currseg.Future[0])// &&
+		// nextIf != none[io.IO_ifs] &&
+		// (get(nextIf) in domain(dp.GetNeighborIAs()))
 }
 
 ghost

--- a/router/io-spec-abstract-transitions.gobra
+++ b/router/io-spec-abstract-transitions.gobra
@@ -128,9 +128,9 @@ pure func AbsValidateEgressIDConstraintXover(pkt io.IO_pkt2, dp io.DataPlaneSpec
 		let rightseg := get(pkt.RightSeg) in
 		let nextIf := (currseg.ConsDir ? currseg.Future[0].EgIF2 : currseg.Future[0].InIF2) in
 		dp.xover_up2down2_link_type_dir(dp.Asid(), rightseg.ConsDir, rightseg.Past[0],
-			currseg.ConsDir, currseg.Future[0])// &&
-		// nextIf != none[io.IO_ifs] &&
-		// (get(nextIf) in domain(dp.GetNeighborIAs()))
+			currseg.ConsDir, currseg.Future[0]) &&
+		nextIf != none[io.IO_ifs] &&
+		(get(nextIf) in domain(dp.GetNeighborIAs()))
 }
 
 ghost
@@ -156,6 +156,7 @@ requires  ElemWitness(ioSharedArg.IBufY, ingressID, oldPkt)
 requires  newPkt == AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
 requires  AbsValidateIngressIDConstraint(oldPkt, ingressID)
 requires  AbsVerifyCurrentMACConstraint(newPkt, dp)
+requires  len(newPkt.CurrSeg.Future) == 1 || AbsValidateEgressIDConstraint(newPkt, true, dp)
 preserves acc(ioLock.LockP(), _) && ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>;
 ensures   dp.Valid()
 ensures   ElemWitness(ioSharedArg.OBufY, egressID, newPkt)
@@ -164,6 +165,9 @@ func InternalEnterEvent(oldPkt io.IO_pkt2, ingressID option[io.IO_ifs], newPkt i
 	reveal AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
 	reveal AbsValidateIngressIDConstraint(oldPkt, ingressID)
 	reveal AbsVerifyCurrentMACConstraint(newPkt, dp)
+	if(len(newPkt.CurrSeg.Future) != 1) {
+		reveal AbsValidateEgressIDConstraint(newPkt, true, dp)
+	}
 	AtomicEnter(oldPkt, ingressID, newPkt, egressID, ioLock, ioSharedArg, dp)
 }
 

--- a/router/io-spec-non-proven-lemmas.gobra
+++ b/router/io-spec-non-proven-lemmas.gobra
@@ -74,39 +74,33 @@ func absPktFutureLemma(dp io.DataPlaneSpec, raw []byte) {
 	assert len(pkt.CurrSeg.Future) > 0
 }
 
-/*
 ghost
-preserves dp.Valid()
-preserves acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R55)
-preserves validPktMetaHdr(raw)
-ensures let LeftSeg := absPkt(dp, raw).LeftSeg in
-	LeftSeg != none[io.IO_seg2] ==>
-		len(get(LeftSeg).History) == 0 && len(get(LeftSeg).Future) > 0
+requires  len(oldPkt.CurrSeg.Future) > 0
+requires  AbsValidateIngressIDConstraint(oldPkt, ingressID)
+requires  newPkt == AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
+ensures   AbsValidateIngressIDConstraint(newPkt, ingressID)
 decreases
-func absPktNextSegmentHistory(dp io.DataPlaneSpec, raw []byte) {
-	pkt := reveal absPkt(dp, raw)
-	reveal validPktMetaHdr(raw)
-	headerOffset := slayers.GetAddressOffset(raw)
-	assert forall k int :: {&raw[headerOffset:headerOffset+scion.MetaLen][k]} 0 <= k && k < scion.MetaLen ==> &raw[headerOffset:headerOffset+scion.MetaLen][k] == &raw[headerOffset + k]
-	hdr := (unfolding acc(sl.AbsSlice_Bytes(raw, 0, len(raw)), R56) in
-			binary.BigEndian.Uint32(raw[headerOffset:headerOffset+scion.MetaLen]))
-	metaHdr := scion.DecodedFrom(hdr)
-	currINFIdx := int(metaHdr.CurrINF)
-	currHFIdx := int(metaHdr.CurrHF)
-	seg1Len := int(metaHdr.SegLen[0])
-	seg2Len := int(metaHdr.SegLen[1])
-	seg3Len := int(metaHdr.SegLen[2])
-	segLen := scion.LengthOfCurrSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
-	prevSegLen := scion.LengthOfPrevSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
-	numINF := scion.NumInfoFields(seg1Len, seg2Len, seg3Len)
-	offset := scion.HopFieldOffset(numINF, 0, headerOffset)
-	assert pkt.LeftSeg == reveal scion.LeftSeg(raw, currINFIdx + 1, seg1Len, seg2Len , seg3Len, headerOffset)
-	if(pkt.LeftSeg != none[io.IO_seg2]) {
-		assert len(get(pkt.LeftSeg).Future) > 0
-		assert len(get(pkt.LeftSeg).History) == 0
-	}
+func AbsValidateIngressIDLemma(oldPkt io.IO_pkt2, newPkt io.IO_pkt2, ingressID option[io.IO_ifs]) {
+	reveal AbsValidateIngressIDConstraint(oldPkt, ingressID)
+	reveal AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
+	reveal AbsValidateIngressIDConstraint(newPkt, ingressID)
 }
-*/
+
+ghost
+requires  len(oldPkt.CurrSeg.Future) == 1
+requires  oldPkt.LeftSeg != none[io.IO_seg2]
+requires  len(get(oldPkt.LeftSeg).Future) > 0
+requires  len(get(oldPkt.LeftSeg).History) == 0
+requires  AbsValidateIngressIDConstraint(oldPkt, ingressID)
+requires  newPkt == AbsDoXover(oldPkt)
+ensures   AbsValidateIngressIDConstraintXover(newPkt, ingressID)
+decreases
+func AbsValidateIngressIDXoverLemma(oldPkt io.IO_pkt2, newPkt io.IO_pkt2, ingressID option[io.IO_ifs]) {
+	reveal AbsValidateIngressIDConstraint(oldPkt, ingressID)
+	reveal AbsDoXover(oldPkt)
+	reveal AbsValidateIngressIDConstraintXover(newPkt, ingressID)
+}
+
 ghost
 opaque
 requires acc(p.scionLayer.Mem(ub), R50)
@@ -119,22 +113,48 @@ pure func (p *scionPacketProcessor) DstIsLocalIngressID(ub []byte) bool {
 		p.scionLayer.DstIA) == (unfolding acc(p.d.Mem(), _) in p.d.localIA)) ==> p.ingressID != 0
 }
 
+ghost
+opaque
+requires acc(p.scionLayer.Mem(ub), R50)
+requires acc(&p.d, R55) && acc(p.d.Mem(), _)
+requires acc(&p.ingressID, R55)
+requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R56)
+requires slayers.ValidPktMetaHdr(ub)
+requires dp.Valid()
+decreases
+pure func (p *scionPacketProcessor) LastHopLen(ub []byte, dp io.DataPlaneSpec) bool {
+	return p.ingressID != 0 &&
+	(unfolding acc(p.scionLayer.Mem(ub), R50) in
+		(unfolding acc(p.scionLayer.HeaderMem(ub[slayers.CmnHdrLen:]), R55) in
+		p.scionLayer.DstIA) == (unfolding acc(p.d.Mem(), _) in p.d.localIA)) ==>
+			len(absPkt(dp, ub).CurrSeg.Future) == 1
+}
+
 //TODO: Does not work with --disableNL --unsafeWildcardoptimization
 ghost
 requires acc(p.scionLayer.Mem(ub), R50)
 requires acc(&p.d, R55) && acc(p.d.Mem(), _)
 requires acc(&p.ingressID, R55)
+requires dp.Valid()
+requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R56)
+requires slayers.ValidPktMetaHdr(ub)
 requires p.DstIsLocalIngressID(ub)
+requires p.LastHopLen(ub, dp)
 requires (unfolding acc(p.scionLayer.Mem(ub), R50) in
 	(unfolding acc(p.scionLayer.HeaderMem(ub[slayers.CmnHdrLen:]), R55) in
 	p.scionLayer.DstIA) == (unfolding acc(p.d.Mem(), _) in p.d.localIA))
 ensures  acc(p.scionLayer.Mem(ub), R50)
 ensures  acc(&p.d, R55) && acc(p.d.Mem(), _)
 ensures  acc(&p.ingressID, R55)
+ensures  dp.Valid()
+ensures  acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R56)
+ensures  slayers.ValidPktMetaHdr(ub)
 ensures  p.ingressID != 0
+ensures  len(absPkt(dp, ub).CurrSeg.Future) == 1
 decreases
-func (p* scionPacketProcessor) GetIngressIDNotZero(ub []byte) {
+func (p* scionPacketProcessor) LocalDstLemma(ub []byte, dp io.DataPlaneSpec) {
 	reveal p.DstIsLocalIngressID(ub)
+	reveal p.LastHopLen(ub, dp)
 }
 
 ghost
@@ -228,7 +248,6 @@ pure func (p* scionPacketProcessor) EqAbsHopField(pkt io.IO_pkt2) bool {
 		absHop.HVF == currHF.HVF
 }
 
-
 ghost
 opaque
 requires acc(&p.infoField, R55)
@@ -241,198 +260,3 @@ pure func (p* scionPacketProcessor) EqAbsInfoField(pkt io.IO_pkt2) bool {
 		absInf.ConsDir == currseg.ConsDir &&
 		absInf.Peer == currseg.Peer
 }
-
-
-/*
-ghost
-requires acc(p.scionLayer.Mem(ub), R55)
-requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R55)
-requires acc(&p.path, R55) && p.path == p.scionLayer.GetPath(ub)
-requires GetIsXoverSpec(ub)
-requires dp.Valid()
-requires validPktMetaHdr(ub)
-ensures acc(p.scionLayer.Mem(ub), R55)
-ensures acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R55)
-ensures acc(&p.path, R55) && p.path == p.scionLayer.GetPath(ub)
-ensures dp.Valid()
-ensures validPktMetaHdr(ub)
-ensures len(absPkt(dp, ub).CurrSeg.Future) == 1
-decreases
-func (p* scionPacketProcessor) SegementChangeLemma(ub []byte, dp io.DataPlaneSpec) {
-	reveal validPktMetaHdr(ub)
-	hdr := (unfolding acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R56) in binary.BigEndian.Uint32(ub[scion.MetaLen]))
-	metaHdr := scion.DecodedFrom(hdr)
-	currINFIdx := int(metaHdr.CurrINF)
-	currHFIdx := int(metaHdr.CurrHF)
-	seg1Len := int(metaHdr.SegLen[0])
-	seg2Len := int(metaHdr.SegLen[1])
-	seg3Len := int(metaHdr.SegLen[2])
-	segLen := LengthOfCurrSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
-	prevSegLen := LengthOfPrevSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
-	numINF := NumInfoFields(seg1Len, seg2Len, seg3Len)
-	offset := HopFieldOffset(numINF, 0)
-	unfold acc(p.path.Mem(ub[start:end]), R55)
-	assert metaHdr == p.path.Base.GetMetaHdr()
-	pkt := reveal absPkt(dp, ub)
-	assert pkt.CurrSeg == reveal CurrSeg(ub, offset+prevSegLen, currINFIdx, currHFIdx-prevSegLen, segLen)
-	fold acc(p.path.Mem(ub[start:end]), R55)
-}
-*/
-/*
-ghost
-requires acc(p.scionLayer.Mem(ub), R55)
-requires acc(&p.path, R55) && p.path == p.scionLayer.GetPath(ub)
-requires acc(&p.path, R55) && acc(p.path.Mem(ub[start:end]), R55)
-requires unfolding acc(p.path.Mem(ub[start:end]), R55) in p.path.GetIsXoverSpec(ub[start:end])
-requires
-ensures
-func (p* scionPacketProcessor) IsXoverLemma(ub []byte, start int, end int) {
-
-}*/
-/*
-ghost
-requires 0 <= start && start <= end && end <= len(ub)
-requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R55)
-requires acc(&p.path, R55) && acc(p.path.Mem(ub[start:end]), R55)
-requires unfolding acc(p.path.Mem(ub[start:end]), R55) in p.path.Base.IsXoverSpec() && p.path.Base.EqAbsHeader(ub)
-requires dp.Valid()
-requires validPktMetaHdr(ub)
-ensures acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R55)
-ensures acc(&p.path, R55) && acc(p.path.Mem(ub[start:end]), R55)
-ensures unfolding acc(p.path.Mem(ub[start:end]), R55) in p.path.Base.IsXoverSpec() && p.path.Base.EqAbsHeader(ub)
-ensures dp.Valid()
-ensures validPktMetaHdr(ub)
-ensures absPkt(dp, ub).LeftSeg != none[io.IO_seg2]
-ensures len(absPkt(dp, ub).CurrSeg.Future) == 1
-decreases
-func (p* scionPacketProcessor) XoverLemma(ub []byte, start int, end int, dp io.DataPlaneSpec) {
-	reveal validPktMetaHdr(ub)
-	hdr := (unfolding acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R56) in binary.BigEndian.Uint32(ub[0:4]))
-	metaHdr := scion.DecodedFrom(hdr)
-	currINFIdx := int(metaHdr.CurrINF)
-	currHFIdx := int(metaHdr.CurrHF)
-	seg1Len := int(metaHdr.SegLen[0])
-	seg2Len := int(metaHdr.SegLen[1])
-	seg3Len := int(metaHdr.SegLen[2])
-	segLen := LengthOfCurrSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
-	prevSegLen := LengthOfPrevSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
-	numINF := NumInfoFields(seg1Len, seg2Len, seg3Len)
-	offset := HopFieldOffset(numINF, 0)
-	unfold acc(p.path.Mem(ub[start:end]), R55)
-	assert metaHdr == p.path.Base.GetMetaHdr()
-	pkt := reveal absPkt(dp, ub)
-	assert pkt.CurrSeg == reveal CurrSeg(ub, offset+prevSegLen, currINFIdx, currHFIdx-prevSegLen, segLen)
-	fold acc(p.path.Mem(ub[start:end]), R55)
-}*/
-/*
-ghost
-requires 0 <= start && start <= end && end <= len(ub)
-requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R55)
-requires acc(&p.path, R55) && acc(p.path.Mem(ub[start:end]), R55)
-requires unfolding acc(p.path.Mem(ub[start:end]), R55) in p.path.Base.IsXoverSpec() && p.path.Base.EqAbsHeader(ub)
-requires dp.Valid()
-requires validPktMetaHdr(ub)
-ensures acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R55)
-ensures acc(&p.path, R55) && acc(p.path.Mem(ub[start:end]), R55)
-ensures unfolding acc(p.path.Mem(ub[start:end]), R55) in p.path.Base.IsXoverSpec() && p.path.Base.EqAbsHeader(ub)
-ensures dp.Valid()
-ensures validPktMetaHdr(ub)
-//ensures absPkt(dp, ub).LeftSeg != none[io.IO_seg2]
-ensures len(absPkt(dp, ub).CurrSeg.Future) == 1
-decreases
-
-func (p* scionPacketProcessor) IncPathLemma(ub []byte, start int, end int, dp io.DataPlaneSpec) {
-	reveal validPktMetaHdr(ub)
-	hdr := (unfolding acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R56) in binary.BigEndian.Uint32(ub[0:4]))
-	metaHdr := scion.DecodedFrom(hdr)
-	currINFIdx := int(metaHdr.CurrINF)
-	currHFIdx := int(metaHdr.CurrHF)
-	seg1Len := int(metaHdr.SegLen[0])
-	seg2Len := int(metaHdr.SegLen[1])
-	seg3Len := int(metaHdr.SegLen[2])
-	segLen := LengthOfCurrSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
-	prevSegLen := LengthOfPrevSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
-	numINF := NumInfoFields(seg1Len, seg2Len, seg3Len)
-	offset := HopFieldOffset(numINF, 0)
-	unfold acc(p.path.Mem(ub[start:end]), R55)
-	reveal p.path.Base.EqAbsHeader(ub)
-	assert metaHdr == p.path.Base.GetMetaHdr()
-	pkt := reveal absPkt(dp, ub)
-	assert pkt.CurrSeg == reveal CurrSeg(ub, offset+prevSegLen, currINFIdx, currHFIdx-prevSegLen, segLen)
-	fold acc(p.path.Mem(ub[start:end]), R55)
-}
-*/
-
-/* {
-	reveal validPktMetaHdr(ub)
-	// hdr := (unfolding acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R56) in binary.BigEndian.Uint32(ub[0:4]))
-	// metaHdr := scion.DecodedFrom(hdr)
-	// currINFIdx := int(metaHdr.CurrINF)
-	// currHFIdx := int(metaHdr.CurrHF)
-	// seg1Len := int(metaHdr.SegLen[0])
-	// seg2Len := int(metaHdr.SegLen[1])
-	// seg3Len := int(metaHdr.SegLen[2])
-	// segLen := LengthOfCurrSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
-	// prevSegLen := LengthOfPrevSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
-	// numINF := NumInfoFields(seg1Len, seg2Len, seg3Len)
-	// offset := HopFieldOffset(numINF, 0)
-	unfold acc(p.path.Mem(ub[start:end]), R55)
-	reveal p.path.Base.EqAbsHeader(ub)
-	unfold acc(p.path.Base.Mem(), _)
-	hdr := p.path.Base
-	//assert metaHdr == p.path.Base.GetMetaHdr()
-	//pkt := reveal absPkt(dp, ub)
-	//assert pkt.CurrSeg == reveal CurrSeg(ub, offset+prevSegLen, currINFIdx, currHFIdx-prevSegLen, segLen)
-	assert hdr.PathMeta.CurrINF == hdr.InfForHfSpec(hdr.PathMeta.CurrHF)
-	assert hdr.PathMeta.CurrINF != hdr.InfForHfSpec(hdr.PathMeta.CurrHF+1)
-	assert hdr.PathMeta.CurrINF < hdr.InfForHfSpec(hdr.PathMeta.CurrHF+1)
-	assert hdr.InfForHfSpec(hdr.PathMeta.CurrHF+1) < hdr.NumINF
-	assert 0 < hdr.PathMeta.SegLen[hdr.PathMeta.CurrINF]
-	assert 0 < hdr.PathMeta.SegLen[hdr.PathMeta.CurrINF + 1]
-	//assert hdr.InfForHfSpec(hdr.PathMeta.CurrINF) == uint8(currINFIdx)
-	//assert currINFIdx + 1 < unfolding acc(p.path.Base.Mem(), _) in p.path.Base.NumINF
-	//assert currINFIdx == 0 ==> seg2Len > 0
-	//assert currINFIdx == 2 ==> seg2Len > 0 && seg3Len > 0
-	//assert p.path.Base.IsXoverSpec() ==> numINF > 1
-	//assert pkt.LeftSeg == reveal LeftSeg(ub, currINFIdx + 1, seg1Len, seg2Len, seg3Len)
-	//fold acc(p.path.Mem(ub[start:end]), R55)
-}*/
-
-/*
-ghost
-requires 0 <= start && start <= end && end <= len(ub)
-requires acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R55)
-requires acc(&p.path, R55) && acc(p.path.Mem(ub[start:end]), R55)
-requires unfolding acc(p.path.Mem(ub[start:end]), R55) in p.path.Base.EqAbsHeader(ub)
-requires dp.Valid()
-requires validPktMetaHdr(ub)
-// ensures acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R55)
-// ensures acc(&p.path, R55) && acc(p.path.Mem(ub[start:end]), R55)
-// ensures unfolding acc(p.path.Mem(ub[start:end]), R55) in p.path.Base.IsXoverSpec() && p.path.Base.EqAbsHeader(ub)
-// ensures dp.Valid()
-// ensures validPktMetaHdr(ub)
-decreases
-func (p* scionPacketProcessor) AbsSetInfoField(ub []byte, start int, end int, dp io.DataPlaneSpec) {
-	reveal validPktMetaHdr(ub)
-	hdr := (unfolding acc(sl.AbsSlice_Bytes(ub, 0, len(ub)), R56) in binary.BigEndian.Uint32(ub[:scion.MetaLen]))
-	metaHdr := scion.DecodedFrom(hdr)
-	currINFIdx := int(metaHdr.CurrINF)
-	currHFIdx := int(metaHdr.CurrHF)
-	seg1Len := int(metaHdr.SegLen[0])
-	seg2Len := int(metaHdr.SegLen[1])
-	seg3Len := int(metaHdr.SegLen[2])
-	segLen := LengthOfCurrSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
-	prevSegLen := LengthOfPrevSeg(currHFIdx, seg1Len, seg2Len, seg3Len)
-	numINF := NumInfoFields(seg1Len, seg2Len, seg3Len)
-	offset := HopFieldOffset(numINF, 0)
-	unfold acc(p.path.Mem(ub[start:end]), R55)
-	reveal p.path.Base.EqAbsHeader(ub)
-	assert metaHdr == p.path.Base.GetMetaHdr()
-	pkt := reveal absPkt(dp, ub)
-	assert pkt.CurrSeg == reveal CurrSeg(ub, offset+prevSegLen, currINFIdx, currHFIdx-prevSegLen, segLen)
-	assert pkt.CurrSeg.Peer == path.BytesToIntermediateAbsInfoField(ub, 0, scion.MetaLen + currINFIdx*path.InfoLen, len(ub)).Peer
-
-	fold acc(p.path.Mem(ub[start:end]), R55)
-
-
-}*/

--- a/router/io-spec-non-proven-lemmas.gobra
+++ b/router/io-spec-non-proven-lemmas.gobra
@@ -123,8 +123,7 @@ requires slayers.ValidPktMetaHdr(ub)
 requires dp.Valid()
 decreases
 pure func (p *scionPacketProcessor) LastHopLen(ub []byte, dp io.DataPlaneSpec) bool {
-	return p.ingressID != 0 &&
-	(unfolding acc(p.scionLayer.Mem(ub), R50) in
+	return (unfolding acc(p.scionLayer.Mem(ub), R50) in
 		(unfolding acc(p.scionLayer.HeaderMem(ub[slayers.CmnHdrLen:]), R55) in
 		p.scionLayer.DstIA) == (unfolding acc(p.d.Mem(), _) in p.d.localIA)) ==>
 			len(absPkt(dp, ub).CurrSeg.Future) == 1

--- a/router/io-spec.gobra
+++ b/router/io-spec.gobra
@@ -147,7 +147,8 @@ ghost
 requires acc(&d.linkTypes, _) && (d.linkTypes != nil ==> acc(d.linkTypes, _))
 decreases
 pure func (d *DataPlane) dpSpecWellConfiguredLinkTypes(dp io.DataPlaneSpec) bool {
-	return forall ifs uint16 :: {ifs in domain(d.linkTypes)} ifs in domain(d.linkTypes) ==>
+	return !(0 in domain(d.linkTypes)) &&
+		forall ifs uint16 :: {ifs in domain(d.linkTypes)} ifs in domain(d.linkTypes) ==>
 		io.IO_ifs(ifs) in domain(dp.GetLinkTypes()) &&
 		absLinktype(d.linkTypes[ifs]) == dp.GetLinkType(io.IO_ifs(ifs))
 }
@@ -161,6 +162,17 @@ pure func (d *DataPlane) DpAgreesWithSpec(dp io.DataPlaneSpec) bool {
 		d.dpSpecWellConfiguredLocalIA(dp)     &&
 		d.dpSpecWellConfiguredNeighborIAs(dp) &&
 		d.dpSpecWellConfiguredLinkTypes(dp)
+}
+
+ghost
+requires acc(d.Mem(), _)
+requires d.DpAgreesWithSpec(dp)
+ensures acc(&d.linkTypes, _) && (d.linkTypes != nil ==> acc(d.linkTypes, _))
+ensures d.dpSpecWellConfiguredLinkTypes(dp)
+decreases
+func (d *DataPlane) LinkTypesLemma(dp io.DataPlaneSpec) {
+	reveal d.DpAgreesWithSpec(dp)
+	unfold acc(d.Mem(), _)
 }
 
 ghost

--- a/verification/io/router.gobra
+++ b/verification/io/router.gobra
@@ -129,7 +129,6 @@ pure func (dp DataPlaneSpec) dp3s_forward_ext(m IO_pkt3, newpkt IO_pkt3, nextif 
 		let hf1, fut := currseg.Future[0], currseg.Future[1:] in
 		let traversedseg := newpkt.CurrSeg in
 		dp.dp2_forward_ext_guard(dp.Asid(), m, nextif, currseg, traversedseg, newpkt, fut, hf1) &&
-		dp.dp2_check_interface_top(currseg.ConsDir, dp.Asid(), hf1) &&
 		(nextif in domain(dp.GetNeighborIAs())) &&
 		let a2 := dp.GetNeighborIA(nextif) in
 		let i2 := dp.Lookup(AsIfsPair{dp.Asid(), nextif}).ifs in

--- a/verification/io/router_events.gobra
+++ b/verification/io/router_events.gobra
@@ -91,6 +91,7 @@ pure func (dp DataPlaneSpec) dp2_enter_guard(m IO_pkt2, currseg IO_seg2, travers
 	return m.CurrSeg == currseg &&
 		currseg.Future == seq[IO_HF]{hf1} ++ fut &&
 		dp.dp2_check_interface(currseg.ConsDir, asid, hf1, recvif) &&
+		(dp.dp2_check_interface_top(currseg.ConsDir, asid, hf1) || fut == seq[IO_HF]{}) &&
 		update_uinfo(!currseg.ConsDir, currseg, traversedseg, hf1) &&
 		same_segment2(currseg, traversedseg) &&
 		same_other2(currseg, traversedseg) &&


### PR DESCRIPTION
- Updated IO-spec for link check logic
- proof of link check logic in `process()`

TODO:
- [ ] prove assumption in `validateEgressID()`
- [x] prove assumption in `validateSrcDstIA()`