### PR TITLE
[Experiment] Disable MCE

### DIFF
--- a/.github/workflows/gobra.yml
+++ b/.github/workflows/gobra.yml
@@ -20,7 +20,7 @@ env:
   parallelizeBranches: '0'
   checkConsistency: '1'
   imageVersion: 'latest'
-  mceMode: 'od'
+  mceMode: 'off'
   requireTriggers: '1'
   useZ3API: '0'
   viperBackend: 'SILICON'
@@ -420,7 +420,7 @@ jobs:
           conditionalizePermissions: '0'
           moreJoins: 'impure'
           imageVersion: ${{ env.imageVersion }}
-          mceMode: 'on'
+          mceMode: 'off'
           requireTriggers: ${{ env.requireTriggers }}
           overflow: ${{ env.overflow }}
           useZ3API: ${{ env.useZ3API }}

--- a/pkg/slayers/scion.go
+++ b/pkg/slayers/scion.go
@@ -229,6 +229,7 @@ func (s *SCION) NetworkFlow() (res gopacket.Flow) {
 // @	(unfolding acc(s.Mem(ubuf), R55) in CmnHdrLen + s.AddrHdrLenSpecInternal() + s.Path.Len(ubuf[CmnHdrLen+s.AddrHdrLenSpecInternal() : s.HdrLen*LineLen])) <= len(ubuf)
 // @ ensures   e != nil ==> e.ErrorMem()
 // @ decreases
+// @ #backend[exhaleMode(1)]
 func (s *SCION) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions /* @ , ghost ubuf []byte @*/) (e error) {
 	// @ unfold acc(s.Mem(ubuf), R0)
 	// @ defer  fold acc(s.Mem(ubuf), R0)
@@ -472,9 +473,10 @@ func (s *SCION) RecyclePaths() {
 // @ ensures   (err == nil && !s.pathPoolInitialized()) ==> PathPoolMem(s.pathPool, s.pathPoolRaw)
 // @ ensures   (err == nil && s.pathPoolInitialized())  ==> (
 // @ 	PathPoolMemExceptOne(s.pathPool, s.pathPoolRaw, pathType) &&
-// @    res === s.getPathPure(pathType))
+// @ 	res === s.getPathPure(pathType))
 // @ ensures   err != nil ==> (PathPoolMem(s.pathPool, s.pathPoolRaw) && err.ErrorMem())
 // @ decreases
+// @ #backend[exhaleMode(1)]
 func (s *SCION) getPath(pathType path.Type) (res path.Path, err error) {
 	// @ unfold PathPoolMem(s.pathPool, s.pathPoolRaw)
 	if s.pathPool == nil {

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -284,6 +284,7 @@ func (d *DataPlane) SetIA(ia addr.IA) (e error) {
 // @ ensures   !d.IsRunning()
 // @ ensures   res == nil ==> d.KeyIsSet()
 // @ decreases 0 if sync.IgnoreBlockingForTermination()
+// @ #backend[exhaleMode(1)]
 func (d *DataPlane) SetKey(key []byte) (res error) {
 	// @ share key
 	d.mtx.Lock()
@@ -344,6 +345,7 @@ func (d *DataPlane) SetKey(key []byte) (res error) {
 // @ ensures   acc(d.Mem(), OutMutexPerm)
 // @ ensures   !d.IsRunning()
 // @ decreases 0 if sync.IgnoreBlockingForTermination()
+// @ #backend[exhaleMode(1)]
 func (d *DataPlane) AddInternalInterface(conn BatchConn, ip net.IP) error {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
@@ -464,6 +466,7 @@ func (d *DataPlane) AddNeighborIA(ifID uint16, remote addr.IA) error {
 // This was reported in https://github.com/scionproto/scion/issues/4282.
 // @ preserves MutexInvariant!<d!>()
 // @ decreases 0 if sync.IgnoreBlockingForTermination()
+// @ #backend[exhaleMode(1)]
 func (d *DataPlane) AddLinkType(ifID uint16, linkTo topology.LinkType) error {
 	// @ unfold acc(d.Mem(), OutMutexPerm)
 	if _, existsB := d.linkTypes[ifID]; existsB {
@@ -1452,7 +1455,7 @@ func (p *scionPacketProcessor) reset() (err error) {
 // @ 	ElemWitness(ioSharedArg.OBufY, newAbsPkt.IO_val_Pkt2_1, newAbsPkt.IO_val_Pkt2_2)
 // @ ensures  reserr != nil && respr.OutPkt != nil ==> newAbsPkt.isIO_val_Unsupported
 // @ decreases 0 if sync.IgnoreBlockingForTermination()
-// @ #backend[moreJoins(1)]
+// @ #backend[exhaleMode(1)]
 func (p *scionPacketProcessor) processPkt(rawPkt []byte,
 	srcAddr *net.UDPAddr /*@, ghost ioLock *sync.Mutex, ghost ioSharedArg SharedArg, ghost dp io.DataPlaneSpec @*/) (respr processResult, reserr error /*@ , addrAliasesPkt bool, ghost newAbsPkt io.IO_val  @*/) {
 
@@ -1757,6 +1760,7 @@ func (p *scionPacketProcessor) processIntraBFD(data []byte) (res error) {
 // @ 	newAbsPkt.isIO_val_Unsupported
 // @ ensures  (respr.OutPkt == nil) == (newAbsPkt == io.IO_val_Unit{})
 // @ decreases 0 if sync.IgnoreBlockingForTermination()
+// @ #backend[exhaleMode(1)]
 func (p *scionPacketProcessor) processSCION( /*@ ghost ub []byte, ghost llIsNil bool, ghost startLL int, ghost endLL int, ghost ioLock *sync.Mutex, ghost ioSharedArg SharedArg, ghost dp io.DataPlaneSpec @*/ ) (respr processResult, reserr error /*@ , addrAliasesPkt bool, ghost newAbsPkt io.IO_val  @*/) {
 
 	var ok bool
@@ -2076,6 +2080,7 @@ func (p *scionPacketProcessor) validateIngressID( /*@ ghost oldPkt io.IO_pkt2, g
 // @ ensures   reserr == nil ==> p.LastHopLen(ubScionL, dp)
 // @ ensures   reserr != nil && respr.OutPkt != nil ==>
 // @ 	absIO_val(dp, respr.OutPkt, respr.EgressID).isIO_val_Unsupported
+// @ #backend[exhaleMode(1)]
 // @ decreases
 func (p *scionPacketProcessor) validateSrcDstIA( /*@ ghost ubScionL []byte, ghost dp io.DataPlaneSpec @*/ ) (respr processResult, reserr error) {
 	// @ unfold acc(p.scionLayer.Mem(ubScionL), R20)
@@ -2942,6 +2947,7 @@ func (p *scionPacketProcessor) ingressRouterAlertFlag() (res *bool) {
 // @ ensures reserr == nil ==> absPkt(dp, ub) == old(absPkt(dp, ub))
 // @ ensures   reserr != nil && respr.OutPkt != nil ==>
 // @ 	absIO_val(dp, respr.OutPkt, respr.EgressID).isIO_val_Unsupported
+// @ #backend[exhaleMode(1)]
 // @ decreases
 func (p *scionPacketProcessor) handleEgressRouterAlert( /*@ ghost ub []byte, ghost llIsNil bool, ghost startLL int, ghost endLL int , ghost dp io.DataPlaneSpec @*/ ) (respr processResult, reserr error) {
 	// @ ghost ubPath := p.scionLayer.UBPath(ub)
@@ -3162,7 +3168,7 @@ func (p *scionPacketProcessor) validatePktLen( /*@ ghost ubScionL []byte, ghost 
 // @ 	newAbsPkt.isIO_val_Unsupported
 // @ ensures (respr.OutPkt == nil) == (newAbsPkt == io.IO_val_Unit{})
 // @ decreases 0 if sync.IgnoreBlockingForTermination()
-// @ #backend[stateConsolidationMode(6)]
+// @ #backend[stateConsolidationMode(6), exhaleMode(1)]
 func (p *scionPacketProcessor) process( /*@ ghost ub []byte, ghost llIsNil bool, ghost startLL int, ghost endLL int, ghost ioLock *sync.Mutex, ghost ioSharedArg SharedArg, ghost dp io.DataPlaneSpec @*/ ) (respr processResult, reserr error /*@, addrAliasesPkt bool, ghost newAbsPkt io.IO_val @*/) {
 	// @ ghost var oldPkt io.IO_pkt2
 	// @ ghost if(slayers.IsSupportedPkt(ub)) {
@@ -3386,6 +3392,7 @@ func (p *scionPacketProcessor) process( /*@ ghost ub []byte, ghost llIsNil bool,
 // @ 	newAbsPkt == absIO_val(dp, respr.OutPkt, respr.EgressID) &&
 // @ 	newAbsPkt.isIO_val_Unsupported
 // @ decreases 0 if sync.IgnoreBlockingForTermination()
+// @ #backend[exhaleMode(1)]
 func (p *scionPacketProcessor) processOHP( /* @ ghost dp io.DataPlaneSpec @ */ ) (respr processResult, reserr error /*@ , addrAliasesPkt bool, ghost newAbsPkt io.IO_val @*/) {
 	// @ ghost ubScionL := p.rawPkt
 	// @ p.scionLayer.ExtractAcc(ubScionL)

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -2080,8 +2080,8 @@ func (p *scionPacketProcessor) validateIngressID( /*@ ghost oldPkt io.IO_pkt2, g
 // @ ensures   reserr == nil ==> p.LastHopLen(ubScionL, dp)
 // @ ensures   reserr != nil && respr.OutPkt != nil ==>
 // @ 	absIO_val(dp, respr.OutPkt, respr.EgressID).isIO_val_Unsupported
-// @ #backend[exhaleMode(1)]
 // @ decreases
+// @ #backend[exhaleMode(1)]
 func (p *scionPacketProcessor) validateSrcDstIA( /*@ ghost ubScionL []byte, ghost dp io.DataPlaneSpec @*/ ) (respr processResult, reserr error) {
 	// @ unfold acc(p.scionLayer.Mem(ubScionL), R20)
 	// @ defer fold acc(p.scionLayer.Mem(ubScionL), R20)
@@ -2947,8 +2947,8 @@ func (p *scionPacketProcessor) ingressRouterAlertFlag() (res *bool) {
 // @ ensures reserr == nil ==> absPkt(dp, ub) == old(absPkt(dp, ub))
 // @ ensures   reserr != nil && respr.OutPkt != nil ==>
 // @ 	absIO_val(dp, respr.OutPkt, respr.EgressID).isIO_val_Unsupported
-// @ #backend[exhaleMode(1)]
 // @ decreases
+// @ #backend[exhaleMode(1)]
 func (p *scionPacketProcessor) handleEgressRouterAlert( /*@ ghost ub []byte, ghost llIsNil bool, ghost startLL int, ghost endLL int , ghost dp io.DataPlaneSpec @*/ ) (respr processResult, reserr error) {
 	// @ ghost ubPath := p.scionLayer.UBPath(ub)
 	// @ ghost startP := p.scionLayer.PathStartIdx(ub)

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -3168,7 +3168,7 @@ func (p *scionPacketProcessor) validatePktLen( /*@ ghost ubScionL []byte, ghost 
 // @ 	newAbsPkt.isIO_val_Unsupported
 // @ ensures (respr.OutPkt == nil) == (newAbsPkt == io.IO_val_Unit{})
 // @ decreases 0 if sync.IgnoreBlockingForTermination()
-// @ #backend[stateConsolidationMode(6), exhaleMode(1)]
+// @ #backend[exhaleMode(1), stateConsolidationMode(6)]
 func (p *scionPacketProcessor) process( /*@ ghost ub []byte, ghost llIsNil bool, ghost startLL int, ghost endLL int, ghost ioLock *sync.Mutex, ghost ioSharedArg SharedArg, ghost dp io.DataPlaneSpec @*/ ) (respr processResult, reserr error /*@, addrAliasesPkt bool, ghost newAbsPkt io.IO_val @*/) {
 	// @ ghost var oldPkt io.IO_pkt2
 	// @ ghost if(slayers.IsSupportedPkt(ub)) {

--- a/router/dataplane_concurrency_model.gobra
+++ b/router/dataplane_concurrency_model.gobra
@@ -137,10 +137,11 @@ pure func addIbuf(s io.IO_dp3s_state_local, val io.IO_val) io.IO_dp3s_state_loca
 }
 
 ghost
-decreases n
 requires dp.dp3s_iospec_ordered(s, t)
 ensures MultiReadBio(t, n)
 ensures dp.dp3s_iospec_ordered(MultiReadBioUpd(t, n, s), MultiReadBioNext(t, n))
+decreases n
+#backend[exhaleMode(1)]
 func ExtractMultiReadBio(
 	dp io.DataPlaneSpec,
 	t io.Place,


### PR DESCRIPTION
This is currently failing due to a bug in Gobra/silver, where nested annotations are not taken into account. Thus, the annotation `// @ #backend[stateConsolidationMode(6), exhaleMode(1)]` is not correctly translated (all but the first annotations are ignored by the backend).