### PR TITLE
Enable `conditionalizePermissions` for the `router`

### DIFF
--- a/.github/workflows/gobra.yml
+++ b/.github/workflows/gobra.yml
@@ -417,7 +417,7 @@ jobs:
           checkConsistency: ${{ env.checkConsistency }}
           chop: 10
           parallelizeBranches: '1'
-          conditionalizePermissions: '0'
+          conditionalizePermissions: '1'
           moreJoins: 'impure'
           imageVersion: ${{ env.imageVersion }}
           mceMode: 'on'


### PR DESCRIPTION
Marco observed that a long time is spent on (sequential) pure function verification in the router package. He also suggested that using `conditionalizePermissions` might reduce the number of branches in these functions (`moreJoins 1` does not have any effect on pure functions), which might speed up verification.