### PR TITLE
Format `info_hop_setter_lemmas.gobra`

### DIFF
--- a/pkg/slayers/path/scion/info_hop_setter_lemmas.gobra
+++ b/pkg/slayers/path/scion/info_hop_setter_lemmas.gobra
@@ -249,10 +249,10 @@ pure func LeftSegWithInfo(
 	segs io.SegLens,
 	inf option[io.AbsInfoField]) option[io.IO_seg3] {
 	return (currInfIdx == 1 && segs.Seg2Len > 0) ?
-			some(CurrSegWithInfo(hopfields, 0, segs.Seg2Len, get(inf))) :
-			(currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
-				some(CurrSegWithInfo(hopfields, 0, segs.Seg3Len, get(inf))) :
-				none[io.IO_seg3]
+		some(CurrSegWithInfo(hopfields, 0, segs.Seg2Len, get(inf))) :
+		(currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
+			some(CurrSegWithInfo(hopfields, 0, segs.Seg3Len, get(inf))) :
+			none[io.IO_seg3]
 }
 
 // RightSegWithInfo returns the abstract representation of the previous segment of a packet.
@@ -276,10 +276,10 @@ pure func RightSegWithInfo(
 	segs io.SegLens,
 	inf option[io.AbsInfoField]) option[io.IO_seg3] {
 	return (currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
-			some(CurrSegWithInfo(hopfields, segs.Seg2Len, segs.Seg2Len, get(inf))) :
-			(currInfIdx == 0 && segs.Seg2Len > 0) ?
-				some(CurrSegWithInfo(hopfields, segs.Seg1Len, segs.Seg1Len, get(inf))) :
-				none[io.IO_seg3]
+		some(CurrSegWithInfo(hopfields, segs.Seg2Len, segs.Seg2Len, get(inf))) :
+		(currInfIdx == 0 && segs.Seg2Len > 0) ?
+			some(CurrSegWithInfo(hopfields, segs.Seg1Len, segs.Seg1Len, get(inf))) :
+			none[io.IO_seg3]
 }
 
 // MidSegWithInfo returns the abstract representation of the last or first segment of a packet.
@@ -303,10 +303,10 @@ pure func MidSegWithInfo(
 	segs io.SegLens,
 	inf option[io.AbsInfoField]) option[io.IO_seg3] {
 	return (currInfIdx == 4 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
-			some(CurrSegWithInfo(hopfields, segs.Seg1Len, segs.Seg1Len, get(inf))) :
-			(currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
-				some(CurrSegWithInfo(hopfields, 0, segs.Seg3Len, get(inf))) :
-				none[io.IO_seg3]
+		some(CurrSegWithInfo(hopfields, segs.Seg1Len, segs.Seg1Len, get(inf))) :
+		(currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
+			some(CurrSegWithInfo(hopfields, 0, segs.Seg3Len, get(inf))) :
+			none[io.IO_seg3]
 }
 
 // CurrSegEquality ensures that the two definitions of abstract segments, CurrSegWithInfo(..)
@@ -496,13 +496,13 @@ decreases
 pure func MidSegEqualitySpec(raw []byte, currInfIdx int, segs io.SegLens) bool {
 	return (segs.Seg2Len > 0 && segs.Seg3Len > 0 &&
 		(currInfIdx == 2 || currInfIdx == 4)) ?
-		let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
-		let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
-		let inf := some(path.BytesToAbsInfoField(infoBytes, 0)) in
-		MidSeg(raw, currInfIdx, segs, MetaLen) ==
-		MidSegWithInfo(hopBytes, currInfIdx, segs, inf) :
-		MidSeg(raw, currInfIdx, segs, MetaLen) ==
-		MidSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
+			let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
+			let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
+			let inf := some(path.BytesToAbsInfoField(infoBytes, 0)) in
+			MidSeg(raw, currInfIdx, segs, MetaLen) ==
+			MidSegWithInfo(hopBytes, currInfIdx, segs, inf) :
+			MidSeg(raw, currInfIdx, segs, MetaLen) ==
+			MidSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
 }
 
 // MidSegEquality ensures that the two definitions of abstract segments, MidSegWithInfo(..)

--- a/pkg/slayers/path/scion/info_hop_setter_lemmas.gobra
+++ b/pkg/slayers/path/scion/info_hop_setter_lemmas.gobra
@@ -17,10 +17,10 @@
 package scion
 
 import (
-    "github.com/scionproto/scion/pkg/slayers/path"
-    . "verification/utils/definitions"
-    sl "verification/utils/slices"
-    "verification/io"
+	"github.com/scionproto/scion/pkg/slayers/path"
+	. "verification/utils/definitions"
+	sl "verification/utils/slices"
+	"verification/io"
 )
 
 /*** This file contains helpful lemmas for proving SetInfoField and SetHopfield. ***/
@@ -42,10 +42,10 @@ requires 0 <= currInfIdx
 requires path.InfoFieldOffset(currInfIdx, MetaLen) + path.InfoLen <= len(raw)
 decreases
 pure func InfofieldByteSlice(raw []byte, currInfIdx int) ([]byte) {
-    return let infOffset := currInfIdx == 4 ?
-        path.InfoFieldOffset(0, MetaLen) :
-        path.InfoFieldOffset(currInfIdx, MetaLen) in
-        raw[infOffset:infOffset+path.InfoLen]
+	return let infOffset := currInfIdx == 4 ?
+		path.InfoFieldOffset(0, MetaLen) :
+		path.InfoFieldOffset(currInfIdx, MetaLen) in
+		raw[infOffset:infOffset+path.InfoLen]
 }
 
 // HopfieldsStartIdx returns index of the first byte of the hopfields of a segment
@@ -58,11 +58,11 @@ requires segs.Valid()
 requires 0 <= currInfIdx
 decreases
 pure func HopfieldsStartIdx(currInfIdx int, segs io.SegLens) int {
-    return let numInf := segs.NumInfoFields() in
-        let infOffset := path.InfoFieldOffset(numInf, MetaLen) in
-        (currInfIdx == 0 || currInfIdx == 4) ? infOffset :
-        currInfIdx == 1 ? infOffset+segs.Seg1Len*path.HopLen :
-        infOffset+(segs.Seg1Len+segs.Seg2Len)*path.HopLen
+	return let numInf := segs.NumInfoFields() in
+		let infOffset := path.InfoFieldOffset(numInf, MetaLen) in
+		(currInfIdx == 0 || currInfIdx == 4) ? infOffset :
+		currInfIdx == 1 ? infOffset+segs.Seg1Len*path.HopLen :
+		infOffset+(segs.Seg1Len+segs.Seg2Len)*path.HopLen
 }
 
 // HopfieldsStartIdx returns index of the last byte of the hopfields of a segment
@@ -75,11 +75,11 @@ requires segs.Valid()
 requires 0 <= currInfIdx
 decreases
 pure func HopfieldsEndIdx(currInfIdx int, segs io.SegLens) int {
-    return let numInf := segs.NumInfoFields() in
-        let infOffset := path.InfoFieldOffset(numInf, MetaLen) in
-        (currInfIdx == 0 || currInfIdx == 4) ? infOffset+segs.Seg1Len*path.HopLen :
-        currInfIdx == 1 ? infOffset+(segs.Seg1Len+segs.Seg2Len)*path.HopLen :
-        infOffset+(segs.Seg1Len+segs.Seg2Len+segs.Seg3Len)*path.HopLen
+	return let numInf := segs.NumInfoFields() in
+		let infOffset := path.InfoFieldOffset(numInf, MetaLen) in
+		(currInfIdx == 0 || currInfIdx == 4) ? infOffset+segs.Seg1Len*path.HopLen :
+		currInfIdx == 1 ? infOffset+(segs.Seg1Len+segs.Seg2Len)*path.HopLen :
+		infOffset+(segs.Seg1Len+segs.Seg2Len+segs.Seg3Len)*path.HopLen
 }
 
 // HopfieldsStartIdx returns returns the byte slice of the hopfields of a segment
@@ -93,11 +93,11 @@ requires 0 <= currInfIdx
 requires PktLen(segs, MetaLen) <= len(raw)
 decreases
 pure func HopfieldsByteSlice(raw []byte, currInfIdx int, segs io.SegLens) ([]byte) {
-    return let numInf := segs.NumInfoFields() in
-        let infOffset := path.InfoFieldOffset(numInf, MetaLen) in
-        let start := HopfieldsStartIdx(currInfIdx, segs) in
-        let end := HopfieldsEndIdx(currInfIdx, segs) in
-        raw[start:end]
+	return let numInf := segs.NumInfoFields() in
+		let infOffset := path.InfoFieldOffset(numInf, MetaLen) in
+		let start := HopfieldsStartIdx(currInfIdx, segs) in
+		let end := HopfieldsEndIdx(currInfIdx, segs) in
+		raw[start:end]
 }
 
 // SliceBytesIntoSegments splits the raw bytes of a packet into its hopfield segments
@@ -113,15 +113,15 @@ ensures  acc(sl.Bytes(HopfieldsByteSlice(raw, 2, segs), 0, segs.Seg3Len*path.Hop
 ensures  acc(sl.Bytes(raw[HopfieldsEndIdx(2, segs):], 0, len(raw[HopfieldsEndIdx(2, segs):])), p)
 decreases
 func SliceBytesIntoSegments(raw []byte, segs io.SegLens, p perm) {
-    sl.SplitByIndex_Bytes(raw, 0, len(raw), HopfieldsStartIdx(0, segs), p)
-    sl.SplitByIndex_Bytes(raw, HopfieldsStartIdx(0, segs), len(raw), HopfieldsEndIdx(0, segs), p)
-    sl.SplitByIndex_Bytes(raw, HopfieldsStartIdx(1, segs), len(raw), HopfieldsEndIdx(1, segs), p)
-    sl.SplitByIndex_Bytes(raw, HopfieldsStartIdx(2, segs), len(raw), HopfieldsEndIdx(2, segs), p)
-    sl.Reslice_Bytes(raw, 0, HopfieldsStartIdx(0, segs), p)
-    sl.Reslice_Bytes(raw, HopfieldsStartIdx(0, segs), HopfieldsEndIdx(0, segs), p)
-    sl.Reslice_Bytes(raw, HopfieldsStartIdx(1, segs), HopfieldsEndIdx(1, segs), p)
-    sl.Reslice_Bytes(raw, HopfieldsStartIdx(2, segs), HopfieldsEndIdx(2, segs), p)
-    sl.Reslice_Bytes(raw, HopfieldsEndIdx(2, segs), len(raw), p)
+	sl.SplitByIndex_Bytes(raw, 0, len(raw), HopfieldsStartIdx(0, segs), p)
+	sl.SplitByIndex_Bytes(raw, HopfieldsStartIdx(0, segs), len(raw), HopfieldsEndIdx(0, segs), p)
+	sl.SplitByIndex_Bytes(raw, HopfieldsStartIdx(1, segs), len(raw), HopfieldsEndIdx(1, segs), p)
+	sl.SplitByIndex_Bytes(raw, HopfieldsStartIdx(2, segs), len(raw), HopfieldsEndIdx(2, segs), p)
+	sl.Reslice_Bytes(raw, 0, HopfieldsStartIdx(0, segs), p)
+	sl.Reslice_Bytes(raw, HopfieldsStartIdx(0, segs), HopfieldsEndIdx(0, segs), p)
+	sl.Reslice_Bytes(raw, HopfieldsStartIdx(1, segs), HopfieldsEndIdx(1, segs), p)
+	sl.Reslice_Bytes(raw, HopfieldsStartIdx(2, segs), HopfieldsEndIdx(2, segs), p)
+	sl.Reslice_Bytes(raw, HopfieldsEndIdx(2, segs), len(raw), p)
 }
 
 // CombineBytesFromSegments combines the three hopfield segments of a packet into a single slice of bytes.
@@ -137,15 +137,15 @@ requires acc(sl.Bytes(raw[HopfieldsEndIdx(2, segs):], 0, len(raw[HopfieldsEndIdx
 ensures  acc(sl.Bytes(raw, 0, len(raw)), p)
 decreases
 func CombineBytesFromSegments(raw []byte, segs io.SegLens, p perm) {
-    sl.Unslice_Bytes(raw, HopfieldsEndIdx(2, segs), len(raw), p)
-    sl.Unslice_Bytes(raw, HopfieldsStartIdx(2, segs), HopfieldsEndIdx(2, segs), p)
-    sl.Unslice_Bytes(raw, HopfieldsStartIdx(1, segs), HopfieldsEndIdx(1, segs), p)
-    sl.Unslice_Bytes(raw, HopfieldsStartIdx(0, segs), HopfieldsEndIdx(0, segs), p)
-    sl.Unslice_Bytes(raw, 0, HopfieldsStartIdx(0, segs), p)
-    sl.CombineAtIndex_Bytes(raw, HopfieldsStartIdx(2, segs), len(raw), HopfieldsEndIdx(2, segs), p)
-    sl.CombineAtIndex_Bytes(raw, HopfieldsStartIdx(1, segs), len(raw), HopfieldsEndIdx(1, segs), p)
-    sl.CombineAtIndex_Bytes(raw, HopfieldsStartIdx(0, segs), len(raw), HopfieldsEndIdx(0, segs), p)
-    sl.CombineAtIndex_Bytes(raw, 0, len(raw), HopfieldsStartIdx(0, segs), p)
+	sl.Unslice_Bytes(raw, HopfieldsEndIdx(2, segs), len(raw), p)
+	sl.Unslice_Bytes(raw, HopfieldsStartIdx(2, segs), HopfieldsEndIdx(2, segs), p)
+	sl.Unslice_Bytes(raw, HopfieldsStartIdx(1, segs), HopfieldsEndIdx(1, segs), p)
+	sl.Unslice_Bytes(raw, HopfieldsStartIdx(0, segs), HopfieldsEndIdx(0, segs), p)
+	sl.Unslice_Bytes(raw, 0, HopfieldsStartIdx(0, segs), p)
+	sl.CombineAtIndex_Bytes(raw, HopfieldsStartIdx(2, segs), len(raw), HopfieldsEndIdx(2, segs), p)
+	sl.CombineAtIndex_Bytes(raw, HopfieldsStartIdx(1, segs), len(raw), HopfieldsEndIdx(1, segs), p)
+	sl.CombineAtIndex_Bytes(raw, HopfieldsStartIdx(0, segs), len(raw), HopfieldsEndIdx(0, segs), p)
+	sl.CombineAtIndex_Bytes(raw, 0, len(raw), HopfieldsStartIdx(0, segs), p)
 }
 
 // SliceBytesIntoInfoFields splits the raw bytes of a packet into its infofields
@@ -162,22 +162,22 @@ ensures  2 < numInf ==> acc(sl.Bytes(InfofieldByteSlice(raw, 2), 0, path.InfoLen
 ensures  acc(sl.Bytes(raw[HopfieldsStartIdx(0, segs):], 0, len(raw[HopfieldsStartIdx(0, segs):])), p)
 decreases
 func SliceBytesIntoInfoFields(raw []byte, numInf int, segs io.SegLens, p perm) {
-    sl.SplitByIndex_Bytes(raw, 0, len(raw), MetaLen, p)
-    sl.SplitByIndex_Bytes(raw, MetaLen, len(raw), path.InfoFieldOffset(1, MetaLen), p)
-    sl.Reslice_Bytes(raw, 0, MetaLen, p)
-    sl.Reslice_Bytes(raw, MetaLen, path.InfoFieldOffset(1, MetaLen), p)
-    if(numInf > 1) {
-        sl.SplitByIndex_Bytes(raw, path.InfoFieldOffset(1, MetaLen), len(raw),
-            path.InfoFieldOffset(2, MetaLen), p)
-        sl.Reslice_Bytes(raw, path.InfoFieldOffset(1, MetaLen),
-            path.InfoFieldOffset(2, MetaLen), p)
-    }
-    if(numInf > 2) {
-        sl.SplitByIndex_Bytes(raw, path.InfoFieldOffset(2, MetaLen), len(raw),
-            HopfieldsStartIdx(0, segs), p)
-        sl.Reslice_Bytes(raw, path.InfoFieldOffset(2, MetaLen), HopfieldsStartIdx(0, segs), p)
-    }
-    sl.Reslice_Bytes(raw, HopfieldsStartIdx(0, segs), len(raw), p)
+	sl.SplitByIndex_Bytes(raw, 0, len(raw), MetaLen, p)
+	sl.SplitByIndex_Bytes(raw, MetaLen, len(raw), path.InfoFieldOffset(1, MetaLen), p)
+	sl.Reslice_Bytes(raw, 0, MetaLen, p)
+	sl.Reslice_Bytes(raw, MetaLen, path.InfoFieldOffset(1, MetaLen), p)
+	if(numInf > 1) {
+		sl.SplitByIndex_Bytes(raw, path.InfoFieldOffset(1, MetaLen), len(raw),
+			path.InfoFieldOffset(2, MetaLen), p)
+		sl.Reslice_Bytes(raw, path.InfoFieldOffset(1, MetaLen),
+			path.InfoFieldOffset(2, MetaLen), p)
+	}
+	if(numInf > 2) {
+		sl.SplitByIndex_Bytes(raw, path.InfoFieldOffset(2, MetaLen), len(raw),
+			HopfieldsStartIdx(0, segs), p)
+		sl.Reslice_Bytes(raw, path.InfoFieldOffset(2, MetaLen), HopfieldsStartIdx(0, segs), p)
+	}
+	sl.Reslice_Bytes(raw, HopfieldsStartIdx(0, segs), len(raw), p)
 }
 
 // CombineBytesFromInfoFields combines the infofields of a packet into a single slice of bytes.
@@ -194,22 +194,22 @@ requires acc(sl.Bytes(raw[HopfieldsStartIdx(0, segs):], 0, len(raw[HopfieldsStar
 ensures  acc(sl.Bytes(raw, 0, len(raw)), p)
 decreases
 func CombineBytesFromInfoFields(raw []byte, numInf int, segs io.SegLens, p perm) {
-    sl.Unslice_Bytes(raw, HopfieldsStartIdx(0, segs), len(raw), p)
-    if(numInf > 2) {
-        sl.Unslice_Bytes(raw, path.InfoFieldOffset(2, MetaLen), HopfieldsStartIdx(0, segs), p)
-        sl.CombineAtIndex_Bytes(raw, path.InfoFieldOffset(2, MetaLen), len(raw),
-            HopfieldsStartIdx(0, segs), p)
-    }
-    if(numInf > 1) {
-        sl.Unslice_Bytes(raw, path.InfoFieldOffset(1, MetaLen),
-            path.InfoFieldOffset(2, MetaLen), p)
-        sl.CombineAtIndex_Bytes(raw, path.InfoFieldOffset(1, MetaLen), len(raw),
-            path.InfoFieldOffset(2, MetaLen), p)
-    }
-    sl.Unslice_Bytes(raw, MetaLen, path.InfoFieldOffset(1, MetaLen), p)
-    sl.Unslice_Bytes(raw, 0, MetaLen, p)
-    sl.CombineAtIndex_Bytes(raw, MetaLen, len(raw), path.InfoFieldOffset(1, MetaLen), p)
-    sl.CombineAtIndex_Bytes(raw, 0, len(raw), MetaLen, p)
+	sl.Unslice_Bytes(raw, HopfieldsStartIdx(0, segs), len(raw), p)
+	if(numInf > 2) {
+		sl.Unslice_Bytes(raw, path.InfoFieldOffset(2, MetaLen), HopfieldsStartIdx(0, segs), p)
+		sl.CombineAtIndex_Bytes(raw, path.InfoFieldOffset(2, MetaLen), len(raw),
+			HopfieldsStartIdx(0, segs), p)
+	}
+	if(numInf > 1) {
+		sl.Unslice_Bytes(raw, path.InfoFieldOffset(1, MetaLen),
+			path.InfoFieldOffset(2, MetaLen), p)
+		sl.CombineAtIndex_Bytes(raw, path.InfoFieldOffset(1, MetaLen), len(raw),
+			path.InfoFieldOffset(2, MetaLen), p)
+	}
+	sl.Unslice_Bytes(raw, MetaLen, path.InfoFieldOffset(1, MetaLen), p)
+	sl.Unslice_Bytes(raw, 0, MetaLen, p)
+	sl.CombineAtIndex_Bytes(raw, MetaLen, len(raw), path.InfoFieldOffset(1, MetaLen), p)
+	sl.CombineAtIndex_Bytes(raw, 0, len(raw), MetaLen, p)
 }
 
 // CurrSegWithInfo returns the abstract representation of the current segment of a packet.
@@ -224,7 +224,7 @@ requires SegLen*path.HopLen == len(hopfields)
 requires acc(sl.Bytes(hopfields, 0, len(hopfields)), R56)
 decreases
 pure func CurrSegWithInfo(hopfields []byte, currHfIdx int, SegLen int, inf io.AbsInfoField) io.IO_seg3 {
-    return segment(hopfields, 0, currHfIdx, inf.AInfo, inf.UInfo, inf.ConsDir, inf.Peer, SegLen)
+	return segment(hopfields, 0, currHfIdx, inf.AInfo, inf.UInfo, inf.ConsDir, inf.Peer, SegLen)
 }
 
 
@@ -236,23 +236,23 @@ ghost
 opaque
 requires segs.Valid()
 requires (currInfIdx == 1 && segs.Seg2Len > 0) ||
-    (currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
-    let start := HopfieldsStartIdx(currInfIdx, segs) in
-    let end := HopfieldsEndIdx(currInfIdx, segs) in
-    inf != none[io.AbsInfoField] &&
-    len(hopfields) == end-start &&
-    acc(sl.Bytes(hopfields, 0, len(hopfields)), R49)
+	(currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
+		let start := HopfieldsStartIdx(currInfIdx, segs) in
+		let end := HopfieldsEndIdx(currInfIdx, segs) in
+		inf != none[io.AbsInfoField] &&
+		len(hopfields) == end-start &&
+		acc(sl.Bytes(hopfields, 0, len(hopfields)), R49)
 decreases
 pure func LeftSegWithInfo(
-    hopfields []byte,
-    currInfIdx int,
-    segs io.SegLens,
-    inf option[io.AbsInfoField]) option[io.IO_seg3] {
-    return (currInfIdx == 1 && segs.Seg2Len > 0) ?
-            some(CurrSegWithInfo(hopfields, 0, segs.Seg2Len, get(inf))) :
-            (currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
-                some(CurrSegWithInfo(hopfields, 0, segs.Seg3Len, get(inf))) :
-                none[io.IO_seg3]
+	hopfields []byte,
+	currInfIdx int,
+	segs io.SegLens,
+	inf option[io.AbsInfoField]) option[io.IO_seg3] {
+	return (currInfIdx == 1 && segs.Seg2Len > 0) ?
+			some(CurrSegWithInfo(hopfields, 0, segs.Seg2Len, get(inf))) :
+			(currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
+				some(CurrSegWithInfo(hopfields, 0, segs.Seg3Len, get(inf))) :
+				none[io.IO_seg3]
 }
 
 // RightSegWithInfo returns the abstract representation of the previous segment of a packet.
@@ -263,23 +263,23 @@ ghost
 opaque
 requires segs.Valid()
 requires (currInfIdx == 0 && segs.Seg2Len > 0) ||
-   (currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
-    let start := HopfieldsStartIdx(currInfIdx, segs) in
-    let end := HopfieldsEndIdx(currInfIdx, segs) in
-    inf != none[io.AbsInfoField] &&
-    len(hopfields) == end-start &&
-    acc(sl.Bytes(hopfields, 0, len(hopfields)), R49)
+	(currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
+		let start := HopfieldsStartIdx(currInfIdx, segs) in
+		let end := HopfieldsEndIdx(currInfIdx, segs) in
+		inf != none[io.AbsInfoField] &&
+		len(hopfields) == end-start &&
+		acc(sl.Bytes(hopfields, 0, len(hopfields)), R49)
 decreases
 pure func RightSegWithInfo(
-    hopfields []byte,
-    currInfIdx int,
-    segs io.SegLens,
-    inf option[io.AbsInfoField]) option[io.IO_seg3] {
-    return (currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
-            some(CurrSegWithInfo(hopfields, segs.Seg2Len, segs.Seg2Len, get(inf))) :
-            (currInfIdx == 0 && segs.Seg2Len > 0) ?
-                some(CurrSegWithInfo(hopfields, segs.Seg1Len, segs.Seg1Len, get(inf))) :
-                none[io.IO_seg3]
+	hopfields []byte,
+	currInfIdx int,
+	segs io.SegLens,
+	inf option[io.AbsInfoField]) option[io.IO_seg3] {
+	return (currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
+			some(CurrSegWithInfo(hopfields, segs.Seg2Len, segs.Seg2Len, get(inf))) :
+			(currInfIdx == 0 && segs.Seg2Len > 0) ?
+				some(CurrSegWithInfo(hopfields, segs.Seg1Len, segs.Seg1Len, get(inf))) :
+				none[io.IO_seg3]
 }
 
 // MidSegWithInfo returns the abstract representation of the last or first segment of a packet.
@@ -290,23 +290,23 @@ ghost
 opaque
 requires segs.Valid()
 requires (segs.Seg2Len > 0 && segs.Seg3Len > 0 &&
-    (currInfIdx == 2 || currInfIdx == 4)) ==>
-    let start := HopfieldsStartIdx(currInfIdx, segs) in
-    let end := HopfieldsEndIdx(currInfIdx, segs) in
-    inf != none[io.AbsInfoField] &&
-    len(hopfields) == end-start &&
-    acc(sl.Bytes(hopfields, 0, len(hopfields)), R49)
+	(currInfIdx == 2 || currInfIdx == 4)) ==>
+		let start := HopfieldsStartIdx(currInfIdx, segs) in
+		let end := HopfieldsEndIdx(currInfIdx, segs) in
+		inf != none[io.AbsInfoField] &&
+		len(hopfields) == end-start &&
+		acc(sl.Bytes(hopfields, 0, len(hopfields)), R49)
 decreases
 pure func MidSegWithInfo(
-    hopfields []byte,
-    currInfIdx int,
-    segs io.SegLens,
-    inf option[io.AbsInfoField]) option[io.IO_seg3] {
-    return (currInfIdx == 4 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
-            some(CurrSegWithInfo(hopfields, segs.Seg1Len, segs.Seg1Len, get(inf))) :
-            (currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
-                some(CurrSegWithInfo(hopfields, 0, segs.Seg3Len, get(inf))) :
-                none[io.IO_seg3]
+	hopfields []byte,
+	currInfIdx int,
+	segs io.SegLens,
+	inf option[io.AbsInfoField]) option[io.IO_seg3] {
+	return (currInfIdx == 4 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
+			some(CurrSegWithInfo(hopfields, segs.Seg1Len, segs.Seg1Len, get(inf))) :
+			(currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
+				some(CurrSegWithInfo(hopfields, 0, segs.Seg3Len, get(inf))) :
+				none[io.IO_seg3]
 }
 
 // CurrSegEquality ensures that the two definitions of abstract segments, CurrSegWithInfo(..)
@@ -321,23 +321,23 @@ preserves acc(sl.Bytes(raw, 0, len(raw)), R50)
 preserves acc(sl.Bytes(raw[offset:offset+SegLen*path.HopLen], 0, SegLen*path.HopLen), R50)
 preserves acc(sl.Bytes(InfofieldByteSlice(raw, currInfIdx), 0, path.InfoLen), R50)
 ensures let inf := path.BytesToAbsInfoField(InfofieldByteSlice(raw, currInfIdx), 0) in
-    CurrSegWithInfo(raw[offset:offset+SegLen*path.HopLen], currHfIdx, SegLen, inf) ==
-    CurrSeg(raw, offset, currInfIdx, currHfIdx, SegLen, MetaLen)
+	CurrSegWithInfo(raw[offset:offset+SegLen*path.HopLen], currHfIdx, SegLen, inf) ==
+	CurrSeg(raw, offset, currInfIdx, currHfIdx, SegLen, MetaLen)
 decreases
 func CurrSegEquality(raw []byte, offset int, currInfIdx int, currHfIdx int, SegLen int) {
-    infoBytes := InfofieldByteSlice(raw, currInfIdx)
-    inf := path.BytesToAbsInfoField(infoBytes, 0)
-    infOffset := path.InfoFieldOffset(currInfIdx, MetaLen)
-    unfold acc(sl.Bytes(raw, 0, len(raw)), R56)
-    unfold acc(sl.Bytes(infoBytes, 0, path.InfoLen), R56)
-    assert reveal path.BytesToAbsInfoField(raw, infOffset) ==
-        reveal path.BytesToAbsInfoField(infoBytes, 0)
-    reveal CurrSeg(raw, offset, currInfIdx, currHfIdx, SegLen, MetaLen)
-    reveal CurrSegWithInfo(raw[offset:offset+SegLen*path.HopLen], currHfIdx, SegLen, inf)
-    fold acc(sl.Bytes(raw, 0, len(raw)), R56)
-    fold acc(sl.Bytes(infoBytes, 0, path.InfoLen), R56)
-    widenSegment(raw, offset, currHfIdx, inf.AInfo, inf.UInfo, inf.ConsDir,
-        inf.Peer, SegLen, offset, offset+SegLen*path.HopLen)
+	infoBytes := InfofieldByteSlice(raw, currInfIdx)
+	inf := path.BytesToAbsInfoField(infoBytes, 0)
+	infOffset := path.InfoFieldOffset(currInfIdx, MetaLen)
+	unfold acc(sl.Bytes(raw, 0, len(raw)), R56)
+	unfold acc(sl.Bytes(infoBytes, 0, path.InfoLen), R56)
+	assert reveal path.BytesToAbsInfoField(raw, infOffset) ==
+		reveal path.BytesToAbsInfoField(infoBytes, 0)
+	reveal CurrSeg(raw, offset, currInfIdx, currHfIdx, SegLen, MetaLen)
+	reveal CurrSegWithInfo(raw[offset:offset+SegLen*path.HopLen], currHfIdx, SegLen, inf)
+	fold acc(sl.Bytes(raw, 0, len(raw)), R56)
+	fold acc(sl.Bytes(infoBytes, 0, path.InfoLen), R56)
+	widenSegment(raw, offset, currHfIdx, inf.AInfo, inf.UInfo, inf.ConsDir,
+		inf.Peer, SegLen, offset, offset+SegLen*path.HopLen)
 }
 
 // UpdateCurrSegInfo proves that updating the infofield from inf1 to inf2 does not alter the hopfields
@@ -348,12 +348,12 @@ requires  0 <= currHfIdx && currHfIdx <= SegLen
 requires  SegLen*path.HopLen == len(raw)
 preserves acc(sl.Bytes(raw, 0, len(raw)), R50)
 ensures   CurrSegWithInfo(raw, currHfIdx, SegLen, inf1).UpdateCurrSeg(inf2) ==
-    CurrSegWithInfo(raw, currHfIdx, SegLen, inf2)
+	CurrSegWithInfo(raw, currHfIdx, SegLen, inf2)
 decreases
 func UpdateCurrSegInfo(raw []byte, currHfIdx int, SegLen int,
-    inf1 io.AbsInfoField, inf2 io.AbsInfoField) {
-    seg1 := reveal CurrSegWithInfo(raw, currHfIdx, SegLen, inf1)
-    seg2 := reveal CurrSegWithInfo(raw, currHfIdx, SegLen, inf2)
+	inf1 io.AbsInfoField, inf2 io.AbsInfoField) {
+	seg1 := reveal CurrSegWithInfo(raw, currHfIdx, SegLen, inf1)
+	seg2 := reveal CurrSegWithInfo(raw, currHfIdx, SegLen, inf2)
 }
 
 
@@ -365,22 +365,22 @@ requires PktLen(segs, MetaLen) <= len(raw)
 requires 1 <= currInfIdx && currInfIdx < 4
 requires acc(sl.Bytes(raw, 0, len(raw)), R49)
 requires (currInfIdx == 1 && segs.Seg2Len > 0) ||
-    (currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
-    let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
-    let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
-    acc(sl.Bytes(infoBytes, 0, path.InfoLen), R49) &&
-    acc(sl.Bytes(hopBytes, 0, len(hopBytes)), R49)
+	(currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
+		let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
+		let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
+		acc(sl.Bytes(infoBytes, 0, path.InfoLen), R49) &&
+		acc(sl.Bytes(hopBytes, 0, len(hopBytes)), R49)
 decreases
 pure func LeftSegEqualitySpec(raw []byte, currInfIdx int, segs io.SegLens) bool {
-    return (currInfIdx == 1 && segs.Seg2Len > 0) ||
-        (currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
-        let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
-        let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
-        let inf := some(path.BytesToAbsInfoField(infoBytes, 0)) in
-        LeftSeg(raw, currInfIdx, segs, MetaLen) ==
-        LeftSegWithInfo(hopBytes, currInfIdx, segs, inf) :
-        LeftSeg(raw, currInfIdx, segs, MetaLen) ==
-        LeftSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
+	return (currInfIdx == 1 && segs.Seg2Len > 0) ||
+		(currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
+		let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
+		let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
+		let inf := some(path.BytesToAbsInfoField(infoBytes, 0)) in
+		LeftSeg(raw, currInfIdx, segs, MetaLen) ==
+		LeftSegWithInfo(hopBytes, currInfIdx, segs, inf) :
+		LeftSeg(raw, currInfIdx, segs, MetaLen) ==
+		LeftSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
 }
 
 // LeftSegEquality ensures that the two definitions of abstract segments, LeftSegWithInfo(..)
@@ -395,27 +395,27 @@ requires  PktLen(segs, MetaLen) <= len(raw)
 requires  1 <= currInfIdx && currInfIdx < 4
 preserves acc(sl.Bytes(raw, 0, len(raw)), R49)
 preserves (currInfIdx == 1 && segs.Seg2Len > 0) ||
-    (currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
-    let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
-    let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
-    acc(sl.Bytes(infoBytes, 0, path.InfoLen), R49) &&
-    acc(sl.Bytes(hopBytes, 0, len(hopBytes)), R49)
+	(currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
+		let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
+		let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
+		acc(sl.Bytes(infoBytes, 0, path.InfoLen), R49) &&
+		acc(sl.Bytes(hopBytes, 0, len(hopBytes)), R49)
 ensures   LeftSegEqualitySpec(raw, currInfIdx, segs)
 decreases
 func LeftSegEquality(raw []byte, currInfIdx int, segs io.SegLens) {
-    reveal LeftSeg(raw, currInfIdx, segs, MetaLen)
-    if ((currInfIdx == 1 && segs.Seg2Len > 0) ||
-        (currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0)) {
-        infoBytes := InfofieldByteSlice(raw, currInfIdx)
-        hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs)
-        inf := some(reveal path.BytesToAbsInfoField(infoBytes, 0))
-        offset := HopfieldsStartIdx(currInfIdx, segs)
-        segLen := currInfIdx == 1 ? segs.Seg2Len : segs.Seg3Len
-        reveal LeftSegWithInfo(hopBytes, currInfIdx, segs, inf)
-        CurrSegEquality(raw, offset, currInfIdx, 0, segLen)
-    } else {
-        reveal LeftSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
-    }
+	reveal LeftSeg(raw, currInfIdx, segs, MetaLen)
+	if ((currInfIdx == 1 && segs.Seg2Len > 0) ||
+		(currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0)) {
+		infoBytes := InfofieldByteSlice(raw, currInfIdx)
+		hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs)
+		inf := some(reveal path.BytesToAbsInfoField(infoBytes, 0))
+		offset := HopfieldsStartIdx(currInfIdx, segs)
+		segLen := currInfIdx == 1 ? segs.Seg2Len : segs.Seg3Len
+		reveal LeftSegWithInfo(hopBytes, currInfIdx, segs, inf)
+		CurrSegEquality(raw, offset, currInfIdx, 0, segLen)
+	} else {
+		reveal LeftSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
+	}
 }
 
 // RightSegEqualitySpec defines the conditions that must hold for RightSegWithInfo(..)
@@ -426,22 +426,22 @@ requires PktLen(segs, MetaLen) <= len(raw)
 requires -1 <= currInfIdx && currInfIdx < 2
 requires acc(sl.Bytes(raw, 0, len(raw)), R49)
 requires (currInfIdx == 0 && segs.Seg2Len > 0) ||
-   (currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
-    let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
-    let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
-    acc(sl.Bytes(infoBytes, 0, path.InfoLen), R49) &&
-    acc(sl.Bytes(hopBytes, 0, len(hopBytes)), R49)
+	(currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
+		let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
+		let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
+		acc(sl.Bytes(infoBytes, 0, path.InfoLen), R49) &&
+		acc(sl.Bytes(hopBytes, 0, len(hopBytes)), R49)
 decreases
 pure func RightSegEqualitySpec(raw []byte, currInfIdx int, segs io.SegLens) bool {
-    return (currInfIdx == 0 && segs.Seg2Len > 0) ||
-        (currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
-        let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
-        let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
-        let inf := some(path.BytesToAbsInfoField(infoBytes, 0)) in
-        RightSeg(raw, currInfIdx, segs, MetaLen) ==
-        RightSegWithInfo(hopBytes, currInfIdx, segs, inf) :
-        RightSeg(raw, currInfIdx, segs, MetaLen) ==
-        RightSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
+	return (currInfIdx == 0 && segs.Seg2Len > 0) ||
+		(currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ?
+		let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
+		let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
+		let inf := some(path.BytesToAbsInfoField(infoBytes, 0)) in
+		RightSeg(raw, currInfIdx, segs, MetaLen) ==
+		RightSegWithInfo(hopBytes, currInfIdx, segs, inf) :
+		RightSeg(raw, currInfIdx, segs, MetaLen) ==
+		RightSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
 }
 
 // RightSegEquality ensures that the two definitions of abstract segments, RightSegWithInfo(..)
@@ -456,27 +456,27 @@ requires  PktLen(segs, MetaLen) <= len(raw)
 requires  -1 <= currInfIdx && currInfIdx < 2
 preserves acc(sl.Bytes(raw, 0, len(raw)), R49)
 preserves (currInfIdx == 0 && segs.Seg2Len > 0) ||
-   (currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
-    let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
-    let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
-    acc(sl.Bytes(infoBytes, 0, path.InfoLen), R49) &&
-    acc(sl.Bytes(hopBytes, 0, len(hopBytes)), R49)
+	(currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
+		let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
+		let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
+		acc(sl.Bytes(infoBytes, 0, path.InfoLen), R49) &&
+		acc(sl.Bytes(hopBytes, 0, len(hopBytes)), R49)
 ensures   RightSegEqualitySpec(raw, currInfIdx, segs)
 decreases
 func RightSegEquality(raw []byte, currInfIdx int, segs io.SegLens) {
-    reveal RightSeg(raw, currInfIdx, segs, MetaLen)
-    if ((currInfIdx == 0 && segs.Seg2Len > 0) ||
-        (currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0)) {
-        infoBytes := InfofieldByteSlice(raw, currInfIdx)
-        hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs)
-        inf := some(reveal path.BytesToAbsInfoField(infoBytes, 0))
-        offset := HopfieldsStartIdx(currInfIdx, segs)
-        segLen := currInfIdx == 0 ? segs.Seg1Len : segs.Seg2Len
-        reveal RightSegWithInfo(hopBytes, currInfIdx, segs, inf)
-        CurrSegEquality(raw, offset, currInfIdx, segLen, segLen)
-    } else {
-        reveal RightSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
-    }
+	reveal RightSeg(raw, currInfIdx, segs, MetaLen)
+	if ((currInfIdx == 0 && segs.Seg2Len > 0) ||
+		(currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0)) {
+		infoBytes := InfofieldByteSlice(raw, currInfIdx)
+		hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs)
+		inf := some(reveal path.BytesToAbsInfoField(infoBytes, 0))
+		offset := HopfieldsStartIdx(currInfIdx, segs)
+		segLen := currInfIdx == 0 ? segs.Seg1Len : segs.Seg2Len
+		reveal RightSegWithInfo(hopBytes, currInfIdx, segs, inf)
+		CurrSegEquality(raw, offset, currInfIdx, segLen, segLen)
+	} else {
+		reveal RightSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
+	}
 }
 
 // MidSegEqualitySpec defines the conditions that must hold for MidSegWithInfo(..)
@@ -487,22 +487,22 @@ requires PktLen(segs, MetaLen) <= len(raw)
 requires 2 <= currInfIdx && currInfIdx < 5
 requires acc(sl.Bytes(raw, 0, len(raw)), R49)
 requires (segs.Seg2Len > 0 && segs.Seg3Len > 0 &&
-    (currInfIdx == 2 || currInfIdx == 4)) ==>
-    let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
-    let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
-    acc(sl.Bytes(infoBytes, 0, path.InfoLen), R49) &&
-    acc(sl.Bytes(hopBytes, 0, len(hopBytes)), R49)
+	(currInfIdx == 2 || currInfIdx == 4)) ==>
+		let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
+		let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
+		acc(sl.Bytes(infoBytes, 0, path.InfoLen), R49) &&
+		acc(sl.Bytes(hopBytes, 0, len(hopBytes)), R49)
 decreases
 pure func MidSegEqualitySpec(raw []byte, currInfIdx int, segs io.SegLens) bool {
-    return (segs.Seg2Len > 0 && segs.Seg3Len > 0 &&
-        (currInfIdx == 2 || currInfIdx == 4)) ?
-        let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
-        let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
-        let inf := some(path.BytesToAbsInfoField(infoBytes, 0)) in
-        MidSeg(raw, currInfIdx, segs, MetaLen) ==
-        MidSegWithInfo(hopBytes, currInfIdx, segs, inf) :
-        MidSeg(raw, currInfIdx, segs, MetaLen) ==
-        MidSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
+	return (segs.Seg2Len > 0 && segs.Seg3Len > 0 &&
+		(currInfIdx == 2 || currInfIdx == 4)) ?
+		let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
+		let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
+		let inf := some(path.BytesToAbsInfoField(infoBytes, 0)) in
+		MidSeg(raw, currInfIdx, segs, MetaLen) ==
+		MidSegWithInfo(hopBytes, currInfIdx, segs, inf) :
+		MidSeg(raw, currInfIdx, segs, MetaLen) ==
+		MidSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
 }
 
 // MidSegEquality ensures that the two definitions of abstract segments, MidSegWithInfo(..)
@@ -517,30 +517,30 @@ requires  PktLen(segs, MetaLen) <= len(raw)
 requires  2 <= currInfIdx && currInfIdx < 5
 preserves acc(sl.Bytes(raw, 0, len(raw)), R49)
 preserves (segs.Seg2Len > 0 && segs.Seg3Len > 0 &&
-    (currInfIdx == 2 || currInfIdx == 4)) ==>
-    let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
-    let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
-    acc(sl.Bytes(infoBytes, 0, path.InfoLen), R49) &&
-    acc(sl.Bytes(hopBytes, 0, len(hopBytes)), R49)
+	(currInfIdx == 2 || currInfIdx == 4)) ==>
+		let infoBytes := InfofieldByteSlice(raw, currInfIdx) in
+		let hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs) in
+		acc(sl.Bytes(infoBytes, 0, path.InfoLen), R49) &&
+		acc(sl.Bytes(hopBytes, 0, len(hopBytes)), R49)
 ensures   MidSegEqualitySpec(raw, currInfIdx, segs)
 decreases
 func MidSegEquality(raw []byte, currInfIdx int, segs io.SegLens) {
-    reveal MidSeg(raw, currInfIdx, segs, MetaLen)
-    if (currInfIdx == 4 && segs.Seg2Len > 0 && segs.Seg3Len > 0) {
-        infoBytes := InfofieldByteSlice(raw, 0)
-        hopBytes := HopfieldsByteSlice(raw, 0, segs)
-        inf := some(reveal path.BytesToAbsInfoField(infoBytes, 0))
-        offset := HopfieldsStartIdx(currInfIdx, segs)
-        reveal MidSegWithInfo(hopBytes, currInfIdx, segs, inf)
-        CurrSegEquality(raw, offset, 0, segs.Seg1Len, segs.Seg1Len)
-    } else if (currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) {
-        infoBytes := InfofieldByteSlice(raw, currInfIdx)
-        hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs)
-        inf := some(reveal path.BytesToAbsInfoField(infoBytes, 0))
-        offset := HopfieldsStartIdx(currInfIdx, segs)
-        reveal MidSegWithInfo(hopBytes, currInfIdx, segs, inf)
-        CurrSegEquality(raw, offset, currInfIdx, 0, segs.Seg3Len)
-    } else {
-        reveal MidSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
-    }
+	reveal MidSeg(raw, currInfIdx, segs, MetaLen)
+	if (currInfIdx == 4 && segs.Seg2Len > 0 && segs.Seg3Len > 0) {
+		infoBytes := InfofieldByteSlice(raw, 0)
+		hopBytes := HopfieldsByteSlice(raw, 0, segs)
+		inf := some(reveal path.BytesToAbsInfoField(infoBytes, 0))
+		offset := HopfieldsStartIdx(currInfIdx, segs)
+		reveal MidSegWithInfo(hopBytes, currInfIdx, segs, inf)
+		CurrSegEquality(raw, offset, 0, segs.Seg1Len, segs.Seg1Len)
+	} else if (currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) {
+		infoBytes := InfofieldByteSlice(raw, currInfIdx)
+		hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs)
+		inf := some(reveal path.BytesToAbsInfoField(infoBytes, 0))
+		offset := HopfieldsStartIdx(currInfIdx, segs)
+		reveal MidSegWithInfo(hopBytes, currInfIdx, segs, inf)
+		CurrSegEquality(raw, offset, currInfIdx, 0, segs.Seg3Len)
+	} else {
+		reveal MidSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
+	}
 }


### PR DESCRIPTION
Use tabs for indentation, which is the idiomatic way in Go.
(changes done originally in #352)