### PR TITLE
New assertion in `Run()` to resolve verification error

### DIFF
--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1032,6 +1032,9 @@ func (d *DataPlane) Run(ctx context.Context /*@, ghost place io.Place, ghost sta
 					// @ assert sl.Bytes(tmpBuf, 0, p.N)
 					// @ assert sl.Bytes(tmpBuf, 0, len(tmpBuf))
 					result, err /*@ , addrAliasesPkt, newAbsPkt @*/ := processor.processPkt(tmpBuf, srcAddr /*@, ioLock, ioSharedArg, dp @*/)
+					// (VerifiedSCION) This assertion is crucial to keep verification stable. Without it,
+					// the fold operation in the branch protected by the condition `result.OutConn == nil`
+					// may fail non-deterministically.
 					// @ assert forall i int :: { &msgs[i] } i0 < i && i < pkts ==>
 					// @ 	MsgToAbsVal(&msgs[i], ingressID) == ioValSeq[i]
 					// @ fold scmpErr.Mem()

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1032,6 +1032,8 @@ func (d *DataPlane) Run(ctx context.Context /*@, ghost place io.Place, ghost sta
 					// @ assert sl.Bytes(tmpBuf, 0, p.N)
 					// @ assert sl.Bytes(tmpBuf, 0, len(tmpBuf))
 					result, err /*@ , addrAliasesPkt, newAbsPkt @*/ := processor.processPkt(tmpBuf, srcAddr /*@, ioLock, ioSharedArg, dp @*/)
+					// @ assert forall i int :: { &msgs[i] } i0 < i && i < pkts ==>
+					// @ 	MsgToAbsVal(&msgs[i], ingressID) == ioValSeq[i]
 					// @ fold scmpErr.Mem()
 
 					switch {


### PR DESCRIPTION
This assertion helps Silicon to prove the corresponding invariant.