### PR TITLE
correct BlockSize in aes NewCipher spec 

### DIFF
--- a/verification/dependencies/crypto/aes/cipher.gobra
+++ b/verification/dependencies/crypto/aes/cipher.gobra
@@ -25,7 +25,7 @@ ensures   err == nil ==>
 ensures   err == nil ==>
 	(result != nil &&
 	result.Mem()   &&
-	result.BlockSize() == len(key))
+	result.BlockSize() == BlockSize)
 ensures   err != nil ==> err.ErrorMem()
 decreases
 func NewCipher(key []byte) (result cipher.Block, err error)


### PR DESCRIPTION
The block size of AES is not dependent on the key size. It is 16 bytes for all key sizes.