### PR TITLE
Disable chopper and parallelizeBranches in the CI

### DIFF
--- a/.github/workflows/gobra.yml
+++ b/.github/workflows/gobra.yml
@@ -415,8 +415,7 @@ jobs:
           includePaths: ${{ env.includePaths }}
           assumeInjectivityOnInhale: ${{ env.assumeInjectivityOnInhale }}
           checkConsistency: ${{ env.checkConsistency }}
-          chop: 10
-          parallelizeBranches: '1'
+          parallelizeBranches: '0'
           conditionalizePermissions: '1'
           moreJoins: 'impure'
           imageVersion: ${{ env.imageVersion }}


### PR DESCRIPTION
The CI has been unreliable due to the race conditions that `--parallelizeBranches` seems to suffer from. This PR disables it, and disables the chopper (this last point slows us down, but drops our reliance on the chopper)