### PR TITLE
Fix contract of `net.isZeros`

### DIFF
--- a/verification/dependencies/net/ip.gobra
+++ b/verification/dependencies/net/ip.gobra
@@ -88,7 +88,7 @@ func (ip IP) To4(ghost wildcard bool) (res IP) {
 	return nil
 }
 
-preserves forall i int :: { &s[i] } 0 <= i && i < len(s) ==> acc(&s[i])
+requires forall i int :: { &s[i] } 0 <= i && i < len(s) ==> acc(&s[i])
 decreases
 pure func isZeros(s []byte) bool
 


### PR DESCRIPTION
Cf. Gobra issue [#943](https://github.com/viperproject/gobra/issues/943)