### PR TITLE
fix syntax according to new versions of Gobra

### DIFF
--- a/pkg/slayers/scion.go
+++ b/pkg/slayers/scion.go
@@ -1028,7 +1028,6 @@ func (s *SCION) pseudoHeaderChecksum(length int, protocol uint8) (res uint32, er
 	// @ invariant 0 <= i && i <= len(s.RawSrcAddr)
 	// @ decreases len(s.RawSrcAddr) - i
 	for i := 0; i < len(s.RawSrcAddr); i += 2 {
-		// @ preserves err == nil
 		// @ requires acc(&s.RawSrcAddr, R20) && acc(sl.Bytes(s.RawSrcAddr, 0, len(s.RawSrcAddr)), R20)
 		// @ requires 0 <= i && i < len(s.RawSrcAddr) && i % 2 == 0 && len(s.RawSrcAddr) % 2 == 0
 		// @ ensures acc(&s.RawSrcAddr, R20) && acc(sl.Bytes(s.RawSrcAddr, 0, len(s.RawSrcAddr)), R20)
@@ -1049,7 +1048,6 @@ func (s *SCION) pseudoHeaderChecksum(length int, protocol uint8) (res uint32, er
 	// @ invariant 0 <= i && i <= len(s.RawDstAddr)
 	// @ decreases len(s.RawDstAddr) - i
 	for i := 0; i < len(s.RawDstAddr); i += 2 {
-		// @ preserves err == nil
 		// @ requires acc(&s.RawDstAddr, R20) && acc(sl.Bytes(s.RawDstAddr, 0, len(s.RawDstAddr)), R20)
 		// @ requires 0 <= i && i < len(s.RawDstAddr) && i % 2 == 0 && len(s.RawDstAddr) % 2 == 0
 		// @ ensures acc(&s.RawDstAddr, R20) && acc(sl.Bytes(s.RawDstAddr, 0, len(s.RawDstAddr)), R20)

--- a/verification/utils/ghost_sync/ghost-mutex.gobra
+++ b/verification/utils/ghost_sync/ghost-mutex.gobra
@@ -50,7 +50,7 @@ func (m gpointer[GhostMutex]) SetInv(inv pred())
 ghost
 requires acc(m.LockP(), _)
 ensures  m.LockP() && m.UnlockP() && m.LockInv()()
-decreases _ if sync.IgnoreBlockingForTermination()
+decreases _
 func (m gpointer[GhostMutex]) Lock()
 
 ghost


### PR DESCRIPTION
The changes to the ghost lock are not safe, but they are meant to be deprecated soon anyway, once #412 is merged