### PR TITLE
Replace custom Asserting function with built-in asserting keyword

### DIFF
--- a/pkg/slayers/scion_spec.gobra
+++ b/pkg/slayers/scion_spec.gobra
@@ -420,9 +420,9 @@ pure func (s *SCION) EqAbsHeader(ub []byte) bool {
 		typeOf(s.Path) == (*scion.Raw) &&
 		unfolding s.Path.Mem(ub[low_:high]) in
 		unfolding sl.Bytes(ub, 0, len(ub))  in
-		let _ := Asserting(forall k int :: {&ub[low_:high][k]} 0 <= k && k < high ==>
+		asserting (forall k int :: {&ub[low_:high][k]} 0 <= k && k < high ==>
 			&ub[low_:high][k] == &ub[low_ + k]) in
-		let _ := Asserting(forall k int :: {&ub[low_:high][:scion.MetaLen][k]} 0 <= k && k < scion.MetaLen ==>
+		asserting (forall k int :: {&ub[low_:high][:scion.MetaLen][k]} 0 <= k && k < scion.MetaLen ==>
 			&ub[low_:high][:scion.MetaLen][k] == &ub[low_:high][k]) in
 		let metaHdr := scion.DecodedFrom(binary.BigEndian.Uint32(ub[low_:high][:scion.MetaLen])) in
 		let seg1 := int(metaHdr.SegLen[0]) in
@@ -462,7 +462,7 @@ pure func ValidPktMetaHdr(raw []byte) bool {
 		let length := GetLength(raw) in
 		length <= len(raw) &&
 		unfolding sl.Bytes(raw, 0, len(raw))       in
-		let _ := Asserting(forall k int :: {&rawHdr[k]} 0 <= k && k < scion.MetaLen ==> &rawHdr[k] == &raw[start + k]) in
+		asserting (forall k int :: {&rawHdr[k]} 0 <= k && k < scion.MetaLen ==> &rawHdr[k] == &raw[start + k]) in
 		let hdr := binary.BigEndian.Uint32(rawHdr) in
 		let metaHdr := scion.DecodedFrom(hdr)      in
 		let seg1 := int(metaHdr.SegLen[0])         in

--- a/verification/utils/definitions/definitions.gobra
+++ b/verification/utils/definitions/definitions.gobra
@@ -96,13 +96,6 @@ func TODO()
 // third party libs
 type PrivateField *int
 
-ghost
-requires b
-decreases
-pure func Asserting(ghost b bool) bool {
-	return true
-}
-
 type Lemma struct{}
 
 // Assumption for IO-Specification


### PR DESCRIPTION
## Summary
This PR removes the custom `Asserting` ghost function and replaces its usages with Gobra's built-in `asserting` keyword, which provides the same functionality with better language integration.

## Key Changes
- Removed the `Asserting` ghost function definition from `verification/utils/definitions/definitions.gobra`
- Replaced three instances of `let _ := Asserting(...)` with the `asserting (...)` keyword in `pkg/slayers/scion_spec.gobra`:
  - Two occurrences in the `EqAbsHeader` method (lines 423-424)
  - One occurrence in the `ValidPktMetaHdr` function (line 465)

## Implementation Details
The `asserting` keyword is a built-in Gobra construct that serves the same purpose as the removed `Asserting` function - it allows assertion of properties within expressions. By using the native keyword instead of a custom wrapper function, the code becomes more idiomatic and reduces unnecessary indirection.

https://claude.ai/code/session_01GeaBhWs7mdKisBuWBRXdt3