### PR TITLE
Remove opaque annotations from ghost functions in verification code

### DIFF
--- a/pkg/slayers/path/infofield.go
+++ b/pkg/slayers/path/infofield.go
@@ -80,7 +80,7 @@ func (inf *InfoField) DecodeFromBytes(raw []byte) (err error) {
 	//@ assert &raw[4:8][2] == &raw[6] && &raw[4:8][3] == &raw[7]
 	inf.Timestamp = binary.BigEndian.Uint32(raw[4:8])
 	//@ fold acc(slices.Bytes(raw, 0, len(raw)), R50)
-	//@ assert reveal BytesToAbsInfoField(raw, 0) ==
+	//@ assert BytesToAbsInfoField(raw, 0) ==
 	//@ 	inf.ToAbsInfoField()
 	return nil
 }
@@ -130,7 +130,7 @@ func (inf *InfoField) SerializeTo(b []byte) (err error) {
 	//@ assert tmpInfo4.AInfo == targetAbsInfo.AInfo
 	//@ fold slices.Bytes(b, 0, len(b))
 	//@ assert inf.ToAbsInfoField() ==
-	//@ 	reveal BytesToAbsInfoField(b, 0)
+	//@ 	BytesToAbsInfoField(b, 0)
 	return nil
 }
 

--- a/pkg/slayers/path/infofield_spec.gobra
+++ b/pkg/slayers/path/infofield_spec.gobra
@@ -74,7 +74,6 @@ pure func AbsUinfo(raw []byte, currINF int, headerOffset int) set[io.MsgTerm] {
 }
 
 ghost
-opaque
 requires 0 <= middle
 requires middle+InfoLen <= len(raw)
 requires sl.Bytes(raw, 0, len(raw))
@@ -114,8 +113,8 @@ func BytesToAbsInfoFieldOffsetEq(raw [] byte, middle int) {
 	end := middle+InfoLen
 	unfold acc(sl.Bytes(raw, 0, len(raw)), R56)
 	unfold acc(sl.Bytes(raw[start:end], 0, InfoLen), R56)
-	absInfo1 := reveal BytesToAbsInfoField(raw, start)
-	absInfo2 := reveal BytesToAbsInfoField(raw[start:end], 0)
+	absInfo1 := BytesToAbsInfoField(raw, start)
+	absInfo2 := BytesToAbsInfoField(raw[start:end], 0)
 
 	assert absInfo1.ConsDir == absInfo2.ConsDir
 	assert absInfo1.Peer == absInfo2.Peer

--- a/pkg/slayers/path/scion/info_hop_setter_lemmas.gobra
+++ b/pkg/slayers/path/scion/info_hop_setter_lemmas.gobra
@@ -217,7 +217,6 @@ func CombineBytesFromInfoFields(raw []byte, numInf int, segs io.SegLens, p perm)
 // the entire raw bytes of the packet. This approach simplifies the verification of changes
 // within a segment after updates to the packet's raw bytes.
 ghost
-opaque
 requires 0 < SegLen
 requires 0 <= currHfIdx && currHfIdx <= SegLen
 requires SegLen * path.HopLen == len(hopfields)
@@ -233,7 +232,6 @@ pure func CurrSegWithInfo(hopfields []byte, currHfIdx int, SegLen int, inf io.Ab
 // the entire bytes of the packet. Whenever the return value is not none, LeftSegWithInfo
 // requires permissions to the hopfields byte slice of the segment specified by currInfIdx.
 ghost
-opaque
 requires segs.Valid()
 requires (currInfIdx == 1 && segs.Seg2Len > 0) ||
 	(currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
@@ -260,7 +258,6 @@ pure func LeftSegWithInfo(
 // the entire bytes of the packet. Whenever the return value is not none, RightSegWithInfo
 // requires permissions to the hopfields byte slice of the segment specified by currInfIdx.
 ghost
-opaque
 requires segs.Valid()
 requires (currInfIdx == 0 && segs.Seg2Len > 0) ||
 	(currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0) ==>
@@ -287,7 +284,6 @@ pure func RightSegWithInfo(
 // the entire bytes of the packet. Whenever the return value is not none, MidSegWithInfo
 // requires permissions to the hopfields byte slice of the segment specified by currInfIdx.
 ghost
-opaque
 requires segs.Valid()
 requires (segs.Seg2Len > 0 && segs.Seg3Len > 0 &&
 	(currInfIdx == 2 || currInfIdx == 4)) ==>
@@ -326,7 +322,7 @@ ensures   let inf := path.BytesToAbsInfoField(InfofieldByteSlice(raw, currInfIdx
 decreases
 func CurrSegEquality(raw []byte, offset int, currInfIdx int, currHfIdx int, SegLen int) {
 	infoBytes := InfofieldByteSlice(raw, currInfIdx)
-	inf := reveal path.BytesToAbsInfoField(infoBytes, 0)
+	inf := path.BytesToAbsInfoField(infoBytes, 0)
 	infOffset := path.InfoFieldOffset(currInfIdx, MetaLen)
 	unfold acc(sl.Bytes(raw, 0, len(raw)), R56)
 	unfold acc(sl.Bytes(infoBytes, 0, path.InfoLen), R56)
@@ -334,13 +330,13 @@ func CurrSegEquality(raw []byte, offset int, currInfIdx int, currHfIdx int, SegL
 	assert path.BytesToAbsInfoField(raw, infOffset) ==
 		path.BytesToAbsInfoField(infoBytes, 0)
 	sl.AssertSliceOverlap(raw, infOffset, offset + SegLen * path.HopLen)
-	currseg1 := reveal CurrSeg(raw, offset, currInfIdx, currHfIdx, SegLen, MetaLen)
-	currseg2 := reveal CurrSegWithInfo(raw[offset:offset + SegLen * path.HopLen], currHfIdx, SegLen, inf)
+	currseg1 := CurrSeg(raw, offset, currInfIdx, currHfIdx, SegLen, MetaLen)
+	currseg2 := CurrSegWithInfo(raw[offset:offset + SegLen * path.HopLen], currHfIdx, SegLen, inf)
 
 	// Establish equality of AInfo
 	sl.AssertSliceOverlap(raw, infOffset+2, infOffset+4)
 	sl.AssertSliceOverlap(raw, infOffset+4, infOffset+8)
-	_ := reveal path.BytesToAbsInfoField(raw, infOffset)
+	_ := path.BytesToAbsInfoField(raw, infOffset)
 	assert currseg1.AInfo == path.Timestamp(raw, currInfIdx, MetaLen)
 	assert currseg2.AInfo == inf.AInfo
 	assert currseg1.AInfo == currseg2.AInfo
@@ -368,8 +364,8 @@ ensures   CurrSegWithInfo(raw, currHfIdx, SegLen, inf1).UpdateCurrSeg(inf2) ==
 decreases
 func UpdateCurrSegInfo(raw []byte, currHfIdx int, SegLen int,
 	inf1 io.AbsInfoField, inf2 io.AbsInfoField) {
-	seg1 := reveal CurrSegWithInfo(raw, currHfIdx, SegLen, inf1)
-	seg2 := reveal CurrSegWithInfo(raw, currHfIdx, SegLen, inf2)
+	seg1 := CurrSegWithInfo(raw, currHfIdx, SegLen, inf1)
+	seg2 := CurrSegWithInfo(raw, currHfIdx, SegLen, inf2)
 }
 
 
@@ -419,18 +415,18 @@ preserves (currInfIdx == 1 && segs.Seg2Len > 0) ||
 ensures   LeftSegEqualitySpec(raw, currInfIdx, segs)
 decreases
 func LeftSegEquality(raw []byte, currInfIdx int, segs io.SegLens) {
-	reveal LeftSeg(raw, currInfIdx, segs, MetaLen)
+	LeftSeg(raw, currInfIdx, segs, MetaLen)
 	if ((currInfIdx == 1 && segs.Seg2Len > 0) ||
 		(currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0)) {
 		infoBytes := InfofieldByteSlice(raw, currInfIdx)
 		hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs)
-		inf := some(reveal path.BytesToAbsInfoField(infoBytes, 0))
+		inf := some(path.BytesToAbsInfoField(infoBytes, 0))
 		offset := HopfieldsStartIdx(currInfIdx, segs)
 		segLen := currInfIdx == 1 ? segs.Seg2Len : segs.Seg3Len
-		reveal LeftSegWithInfo(hopBytes, currInfIdx, segs, inf)
+		LeftSegWithInfo(hopBytes, currInfIdx, segs, inf)
 		CurrSegEquality(raw, offset, currInfIdx, 0, segLen)
 	} else {
-		reveal LeftSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
+		LeftSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
 	}
 }
 
@@ -480,18 +476,18 @@ preserves (currInfIdx == 0 && segs.Seg2Len > 0) ||
 ensures   RightSegEqualitySpec(raw, currInfIdx, segs)
 decreases
 func RightSegEquality(raw []byte, currInfIdx int, segs io.SegLens) {
-	reveal RightSeg(raw, currInfIdx, segs, MetaLen)
+	RightSeg(raw, currInfIdx, segs, MetaLen)
 	if ((currInfIdx == 0 && segs.Seg2Len > 0) ||
 		(currInfIdx == 1 && segs.Seg2Len > 0 && segs.Seg3Len > 0)) {
 		infoBytes := InfofieldByteSlice(raw, currInfIdx)
 		hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs)
-		inf := some(reveal path.BytesToAbsInfoField(infoBytes, 0))
+		inf := some(path.BytesToAbsInfoField(infoBytes, 0))
 		offset := HopfieldsStartIdx(currInfIdx, segs)
 		segLen := currInfIdx == 0 ? segs.Seg1Len : segs.Seg2Len
-		reveal RightSegWithInfo(hopBytes, currInfIdx, segs, inf)
+		RightSegWithInfo(hopBytes, currInfIdx, segs, inf)
 		CurrSegEquality(raw, offset, currInfIdx, segLen, segLen)
 	} else {
-		reveal RightSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
+		RightSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
 	}
 }
 
@@ -541,23 +537,23 @@ preserves (segs.Seg2Len > 0 && segs.Seg3Len > 0 &&
 ensures   MidSegEqualitySpec(raw, currInfIdx, segs)
 decreases
 func MidSegEquality(raw []byte, currInfIdx int, segs io.SegLens) {
-	reveal MidSeg(raw, currInfIdx, segs, MetaLen)
+	MidSeg(raw, currInfIdx, segs, MetaLen)
 	if (currInfIdx == 4 && segs.Seg2Len > 0 && segs.Seg3Len > 0) {
 		infoBytes := InfofieldByteSlice(raw, 0)
 		hopBytes := HopfieldsByteSlice(raw, 0, segs)
-		inf := some(reveal path.BytesToAbsInfoField(infoBytes, 0))
+		inf := some(path.BytesToAbsInfoField(infoBytes, 0))
 		offset := HopfieldsStartIdx(currInfIdx, segs)
-		reveal MidSegWithInfo(hopBytes, currInfIdx, segs, inf)
+		MidSegWithInfo(hopBytes, currInfIdx, segs, inf)
 		CurrSegEquality(raw, offset, 0, segs.Seg1Len, segs.Seg1Len)
 	} else if (currInfIdx == 2 && segs.Seg2Len > 0 && segs.Seg3Len > 0) {
 		infoBytes := InfofieldByteSlice(raw, currInfIdx)
 		hopBytes := HopfieldsByteSlice(raw, currInfIdx, segs)
-		inf := some(reveal path.BytesToAbsInfoField(infoBytes, 0))
+		inf := some(path.BytesToAbsInfoField(infoBytes, 0))
 		offset := HopfieldsStartIdx(currInfIdx, segs)
-		reveal MidSegWithInfo(hopBytes, currInfIdx, segs, inf)
+		MidSegWithInfo(hopBytes, currInfIdx, segs, inf)
 		CurrSegEquality(raw, offset, currInfIdx, 0, segs.Seg3Len)
 	} else {
-		reveal MidSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
+		MidSegWithInfo(nil, currInfIdx, segs, none[io.AbsInfoField])
 	}
 }
 
@@ -606,7 +602,7 @@ preserves let currHfStart := currHfIdx * path.HopLen in
 ensures  BytesStoreCurrSeg(hopfields, currHfIdx, segLen, inf)
 decreases
 func EstablishBytesStoreCurrSeg(hopfields []byte, currHfIdx int, segLen int, inf io.AbsInfoField) {
-	currseg := reveal CurrSegWithInfo(hopfields, currHfIdx, segLen, inf)
+	currseg := CurrSegWithInfo(hopfields, currHfIdx, segLen, inf)
 	currHfStart := currHfIdx * path.HopLen
 	currHfEnd := currHfStart + path.HopLen
 

--- a/pkg/slayers/path/scion/raw.go
+++ b/pkg/slayers/path/scion/raw.go
@@ -249,7 +249,7 @@ func (s *Raw) ToDecoded( /*@ ghost ubuf []byte @*/ ) (d *Decoded, err error) {
 // @ decreases
 func (s *Raw) IncPath( /*@ ghost ubuf []byte @*/ ) (r error) {
 	//@ unfold s.Mem(ubuf)
-	//@ reveal validPktMetaHdr(ubuf)
+	//@ validPktMetaHdr(ubuf)
 	//@ unfold acc(s.Base.Mem(), R56)
 	//@ oldCurrInfIdx := int(s.PathMeta.CurrINF)
 	//@ oldCurrHfIdx := int(s.PathMeta.CurrHF)
@@ -277,7 +277,7 @@ func (s *Raw) IncPath( /*@ ghost ubuf []byte @*/ ) (r error) {
 	//@ WidenMidSeg(ubuf, oldCurrInfIdx + 2, oldSegs, MetaLen, MetaLen, len(ubuf))
 	//@ WidenRightSeg(ubuf, oldCurrInfIdx - 1, oldSegs, MetaLen, MetaLen, len(ubuf))
 	//@ LenCurrSeg(tail, oldOffset, oldCurrInfIdx, oldHfIdxSeg, oldSegLen)
-	//@ oldAbsPkt := reveal s.absPkt(ubuf)
+	//@ oldAbsPkt := s.absPkt(ubuf)
 	//@ sl.SplitRange_Bytes(ubuf, 0, MetaLen, HalfPerm)
 	//@ unfold acc(s.Base.Mem(), R2)
 	err := s.PathMeta.SerializeTo(s.Raw[:MetaLen])
@@ -294,7 +294,7 @@ func (s *Raw) IncPath( /*@ ghost ubuf []byte @*/ ) (r error) {
 	//@ sl.CombineRange_Bytes(ubuf, 0, MetaLen, HalfPerm)
 	//@ ValidPktMetaHdrSublice(ubuf, MetaLen)
 	//@ assert s.EqAbsHeader(ubuf) == s.PathMeta.EqAbsHeader(ubuf)
-	//@ assert reveal validPktMetaHdr(ubuf)
+	//@ assert validPktMetaHdr(ubuf)
 	//@ currInfIdx := int(s.PathMeta.CurrINF)
 	//@ currHfIdx := int(s.PathMeta.CurrHF)
 	//@ assert currHfIdx == oldCurrHfIdx + 1
@@ -306,7 +306,7 @@ func (s *Raw) IncPath( /*@ ghost ubuf []byte @*/ ) (r error) {
 	//@ 	WidenLeftSeg(ubuf, oldCurrInfIdx + 1, oldSegs, MetaLen, MetaLen, len(ubuf))
 	//@ 	WidenMidSeg(ubuf, oldCurrInfIdx + 2, oldSegs, MetaLen, MetaLen, len(ubuf))
 	//@ 	WidenRightSeg(ubuf, oldCurrInfIdx - 1, oldSegs, MetaLen, MetaLen, len(ubuf))
-	//@ 	assert reveal s.absPkt(ubuf) == AbsIncPath(oldAbsPkt)
+	//@ 	assert s.absPkt(ubuf) == AbsIncPath(oldAbsPkt)
 	//@ } else {
 	//@ 	segLen := oldSegs.LengthOfCurrSeg(currHfIdx)
 	//@ 	prevSegLen := oldSegs.LengthOfPrevSeg(currHfIdx)
@@ -321,7 +321,7 @@ func (s *Raw) IncPath( /*@ ghost ubuf []byte @*/ ) (r error) {
 	//@ 	WidenLeftSeg(ubuf, currInfIdx + 1, oldSegs, MetaLen, MetaLen, len(ubuf))
 	//@ 	WidenMidSeg(ubuf, currInfIdx + 2, oldSegs, MetaLen, MetaLen, len(ubuf))
 	//@ 	WidenRightSeg(ubuf, currInfIdx - 1, oldSegs, MetaLen, MetaLen, len(ubuf))
-	//@ 	assert reveal s.absPkt(ubuf) == AbsXover(oldAbsPkt)
+	//@ 	assert s.absPkt(ubuf) == AbsXover(oldAbsPkt)
 	//@ }
 
 	//@ fold acc(sl.Bytes(tail, 0, len(tail)), R50)
@@ -361,7 +361,7 @@ func (s *Raw) GetInfoField(idx int /*@, ghost ubuf []byte @*/) (ifield path.Info
 	//@ path.BytesToAbsInfoFieldOffsetEq(ubuf, infOffset)
 	//@ sl.CombineRange_Bytes(ubuf, infOffset, infOffset+path.InfoLen, R21)
 	//@ fold acc(s.Mem(ubuf), R11)
-	//@ assert reveal s.CorrectlyDecodedInfWithIdx(ubuf, idx, info)
+	//@ assert s.CorrectlyDecodedInfWithIdx(ubuf, idx, info)
 	return info, nil
 }
 
@@ -383,7 +383,7 @@ func (s *Raw) GetCurrentInfoField( /*@ ghost ubuf []byte @*/ ) (res path.InfoFie
 	//@ fold acc(s.Base.Mem(), R10)
 	//@ fold acc(s.Mem(ubuf), R9)
 	//@ assert forall res path.InfoField :: { s.CorrectlyDecodedInf(ubuf, res) } s.GetBase(ubuf).ValidCurrInfSpec() ==>
-	//@ 	reveal s.CorrectlyDecodedInf(ubuf, res) == reveal s.CorrectlyDecodedInfWithIdx(ubuf, idx, res)
+	//@ 	s.CorrectlyDecodedInf(ubuf, res) == s.CorrectlyDecodedInfWithIdx(ubuf, idx, res)
 	return s.GetInfoField(idx /*@, ubuf @*/)
 }
 
@@ -408,7 +408,7 @@ func (s *Raw) GetCurrentInfoField( /*@ ghost ubuf []byte @*/ ) (res path.InfoFie
 // @ #backend[exhaleMode(1)]
 func (s *Raw) SetInfoField(info path.InfoField, idx int /*@, ghost ubuf []byte @*/) (r error) {
 	//@ share info
-	//@ reveal validPktMetaHdr(ubuf)
+	//@ validPktMetaHdr(ubuf)
 	//@ unfold acc(s.Mem(ubuf), R50)
 	//@ unfold acc(s.Base.Mem(), R50)
 	//@ currInfIdx := int(s.PathMeta.CurrINF)
@@ -443,21 +443,21 @@ func (s *Raw) SetInfoField(info path.InfoField, idx int /*@, ghost ubuf []byte @
 	//@ 	MidSegEquality(ubuf, currInfIdx+2, segLens)
 	//@ 	RightSegEquality(ubuf, currInfIdx-1, segLens)
 	//@ }
-	//@ reveal s.absPkt(ubuf)
+	//@ s.absPkt(ubuf)
 	//@ sl.SplitRange_Bytes(ubuf[:hopfieldOffset], infOffset, infOffset+path.InfoLen, R40)
 	//@ sl.SplitRange_Bytes(ubuf, infOffset, infOffset+path.InfoLen, HalfPerm-R40)
 	ret := info.SerializeTo(s.Raw[infOffset : infOffset+path.InfoLen])
 	//@ sl.CombineRange_Bytes(ubuf[:hopfieldOffset], infOffset, infOffset+path.InfoLen, R40)
 	//@ sl.CombineRange_Bytes(ubuf, infOffset, infOffset+path.InfoLen, HalfPerm-R40)
 	//@ ValidPktMetaHdrSublice(ubuf, MetaLen)
-	//@ assert reveal validPktMetaHdr(ubuf)
+	//@ assert validPktMetaHdr(ubuf)
 	//@ ghost if idx == currInfIdx {
 	//@ 	CurrSegEquality(ubuf, offset, currInfIdx, hfIdxSeg, segLen)
 	//@ 	UpdateCurrSegInfo(hopfields, hfIdxSeg, segLen, oldInfo, newInfo)
 	//@ 	LeftSegEquality(ubuf, currInfIdx+1, segLens)
 	//@ 	MidSegEquality(ubuf, currInfIdx+2, segLens)
 	//@ 	RightSegEquality(ubuf, currInfIdx-1, segLens)
-	//@ 	reveal s.absPkt(ubuf)
+	//@ 	s.absPkt(ubuf)
 	//@ }
 	//@ CombineBytesFromSegments(ubuf, segLens, R40)
 	//@ CombineBytesFromInfoFields(ubuf, s.NumINF, segLens, HalfPerm)
@@ -496,7 +496,7 @@ func (s *Raw) GetHopField(idx int /*@, ghost ubuf []byte @*/) (res path.HopField
 	//@ path.BytesToAbsHopFieldOffsetEq(ubuf, hopOffset)
 	//@ sl.CombineRange_Bytes(ubuf, hopOffset, hopOffset+path.HopLen, R21)
 	//@ fold acc(s.Mem(ubuf), R11)
-	//@ assert reveal s.CorrectlyDecodedHfWithIdx(ubuf, idx, hop)
+	//@ assert s.CorrectlyDecodedHfWithIdx(ubuf, idx, hop)
 	return hop, nil
 }
 
@@ -518,7 +518,7 @@ func (s *Raw) GetCurrentHopField( /*@ ghost ubuf []byte @*/ ) (res path.HopField
 	//@ fold acc(s.Base.Mem(), R10)
 	//@ fold acc(s.Mem(ubuf), R9)
 	//@ assert forall res path.HopField :: { s.CorrectlyDecodedHf(ubuf, res) } s.GetBase(ubuf).ValidCurrHfSpec() ==>
-	//@ 	reveal s.CorrectlyDecodedHf(ubuf, res) == reveal s.CorrectlyDecodedHfWithIdx(ubuf, idx, res)
+	//@ 	s.CorrectlyDecodedHf(ubuf, res) == s.CorrectlyDecodedHfWithIdx(ubuf, idx, res)
 	return s.GetHopField(idx /*@, ubuf @*/)
 }
 
@@ -552,7 +552,7 @@ func (s *Raw) SetHopField(hop path.HopField, idx int /*@, ghost ubuf []byte @*/)
 	// https://github.com/viperproject/gobra/issues/192
 	//@ assume 0 <= tmpHopField.ConsIngress && 0 <= tmpHopField.ConsEgress
 	//@ fold acc(tmpHopField.Mem(), R9)
-	//@ reveal validPktMetaHdr(ubuf)
+	//@ validPktMetaHdr(ubuf)
 	//@ unfold acc(s.Mem(ubuf), R50)
 	//@ unfold acc(s.Base.Mem(), R50)
 	//@ ghost currInfIdx := int(s.PathMeta.CurrINF)
@@ -586,7 +586,7 @@ func (s *Raw) SetHopField(hop path.HopField, idx int /*@, ghost ubuf []byte @*/)
 	//@ 	LeftSegEquality(ubuf, currInfIdx+1, segLens)
 	//@ 	MidSegEquality(ubuf, currInfIdx+2, segLens)
 	//@ 	RightSegEquality(ubuf, currInfIdx-1, segLens)
-	//@ 	reveal s.absPkt(ubuf)
+	//@ 	s.absPkt(ubuf)
 	//@ 	SplitHopfields(currHopfields, hfIdxSeg, segLen, R0)
 	//@ 	EstablishBytesStoreCurrSeg(currHopfields, hfIdxSeg, segLen, inf)
 	//@ 	SplitHopfields(currHopfields, hfIdxSeg, segLen, R0)
@@ -598,7 +598,7 @@ func (s *Raw) SetHopField(hop path.HopField, idx int /*@, ghost ubuf []byte @*/)
 	ret := tmpHopField.SerializeTo(s.Raw[hopOffset : hopOffset+path.HopLen])
 	//@ sl.CombineRange_Bytes(ubuf, hopOffset, hopOffset+path.HopLen, HalfPerm)
 	//@ ValidPktMetaHdrSublice(ubuf, MetaLen)
-	//@ assert reveal validPktMetaHdr(ubuf)
+	//@ assert validPktMetaHdr(ubuf)
 	//@ ghost if idx == currHfIdx {
 	//@ 	CombineHopfields(currHopfields, hfIdxSeg, segLen, R0)
 	//@ 	EstablishBytesStoreCurrSeg(currHopfields, hfIdxSeg, segLen, inf)
@@ -607,7 +607,7 @@ func (s *Raw) SetHopField(hop path.HopField, idx int /*@, ghost ubuf []byte @*/)
 	//@ 	LeftSegEquality(ubuf, currInfIdx+1, segLens)
 	//@ 	MidSegEquality(ubuf, currInfIdx+2, segLens)
 	//@ 	RightSegEquality(ubuf, currInfIdx-1, segLens)
-	//@ 	reveal s.absPkt(ubuf)
+	//@ 	s.absPkt(ubuf)
 	//@ 	assert s.absPkt(ubuf).CurrSeg.Future ==
 	//@ 		seq[io.HF]{tmpHopField.Abs()} ++ old(s.absPkt(ubuf).CurrSeg.Future[1:])
 	//@ } else {

--- a/pkg/slayers/path/scion/raw_spec.gobra
+++ b/pkg/slayers/path/scion/raw_spec.gobra
@@ -282,7 +282,6 @@ pure func segment(raw []byte,
 }
 
 ghost
-opaque
 requires sl.Bytes(raw, 0, len(raw))
 requires 0 <= headerOffset
 requires path.InfoFieldOffset(currInfIdx, headerOffset) + path.InfoLen <= offset
@@ -308,7 +307,6 @@ pure func CurrSeg(raw []byte,
 }
 
 ghost
-opaque
 requires sl.Bytes(raw, 0, len(raw))
 requires 0 <= headerOffset
 requires segs.Valid()
@@ -329,7 +327,6 @@ pure func LeftSeg(
 }
 
 ghost
-opaque
 requires sl.Bytes(raw, 0, len(raw))
 requires 0 <= headerOffset
 requires segs.Valid()
@@ -350,7 +347,6 @@ pure func RightSeg(
 }
 
 ghost
-opaque
 requires sl.Bytes(raw, 0, len(raw))
 requires 0 <= headerOffset
 requires segs.Valid()
@@ -371,13 +367,12 @@ pure func MidSeg(
 }
 
 ghost
-opaque
 requires sl.Bytes(raw, 0, len(raw))
 requires validPktMetaHdr(raw)
 decreases
 // TODO: rename this to View()
 pure func (s *Raw) absPkt(raw []byte) (res io.Pkt) {
-	return let _ := reveal validPktMetaHdr(raw) in
+	return let _ := validPktMetaHdr(raw) in
 		let metaHdr := RawBytesToMetaHdr(raw)  in
 		let currInfIdx := int(metaHdr.CurrINF) in
 		let currHfIdx := int(metaHdr.CurrHF)   in
@@ -421,7 +416,6 @@ pure func RawBytesToBase(raw []byte) Base {
 }
 
 ghost
-opaque
 requires sl.Bytes(raw, 0, len(raw))
 decreases
 pure func validPktMetaHdr(raw []byte) bool {
@@ -445,8 +439,8 @@ ensures   RawBytesToMetaHdr(raw) == RawBytesToMetaHdr(raw[:idx])
 ensures   RawBytesToBase(raw) == RawBytesToBase(raw[:idx])
 decreases
 func ValidPktMetaHdrSublice(raw []byte, idx int) {
-	reveal validPktMetaHdr(raw)
-	reveal validPktMetaHdr(raw[:idx])
+	validPktMetaHdr(raw)
+	validPktMetaHdr(raw[:idx])
 	unfold acc(sl.Bytes(raw, 0, len(raw)), R56)
 	unfold acc(sl.Bytes(raw[:idx], 0, idx), R56)
 	assert forall i int :: { &raw[:MetaLen][i] } 0 <= i && i < MetaLen ==>
@@ -477,7 +471,7 @@ func (s *Raw) EstablishValidPktMetaHdr(ghost ub []byte) {
 	assert 0 < seg1
 	assert s.GetBase(ub).NumsCompatibleWithSegLen()
 	assert PktLen(segs, MetaLen) <= len(ub)
-	assert reveal validPktMetaHdr(ub)
+	assert validPktMetaHdr(ub)
 	fold acc(s.Base.Mem(), R56)
 	fold acc(s.Mem(ub), R55)
 }
@@ -532,7 +526,6 @@ pure func (s *Raw) IsLastHopSpec(ub []byte) bool {
 }
 
 ghost
-opaque
 requires s.Mem(ub)
 requires 0 <= idx && idx < s.GetNumINF(ub)
 requires sl.Bytes(ub, 0, len(ub))
@@ -543,11 +536,10 @@ pure func (s *Raw) CorrectlyDecodedInfWithIdx(ub []byte, idx int, info path.Info
 		let infOffset := MetaLen + idx*path.InfoLen in
 		infOffset + path.InfoLen <= len(ub) &&
 		info.ToAbsInfoField() ==
-			reveal path.BytesToAbsInfoField(ub, infOffset)
+			path.BytesToAbsInfoField(ub, infOffset)
 }
 
 ghost
-opaque
 requires s.Mem(ub)
 requires s.GetBase(ub).ValidCurrInfSpec()
 requires sl.Bytes(ub, 0, len(ub))
@@ -558,11 +550,10 @@ pure func (s *Raw) CorrectlyDecodedInf(ub []byte, info path.InfoField) bool {
 		let infOffset := MetaLen + int(s.Base.PathMeta.CurrINF) * path.InfoLen in
 		infOffset + path.InfoLen <= len(ub) &&
 		info.ToAbsInfoField() ==
-			reveal path.BytesToAbsInfoField(ub, infOffset)
+			path.BytesToAbsInfoField(ub, infOffset)
 }
 
 ghost
-opaque
 requires s.Mem(ub)
 requires 0 <= idx && idx < s.GetNumHops(ub)
 requires sl.Bytes(ub, 0, len(ub))
@@ -576,7 +567,6 @@ pure func (s *Raw) CorrectlyDecodedHfWithIdx(ub []byte, idx int, hop path.HopFie
 }
 
 ghost
-opaque
 requires s.Mem(ub)
 requires s.GetBase(ub).ValidCurrHfSpec()
 requires sl.Bytes(ub, 0, len(ub))
@@ -599,7 +589,7 @@ preserves s.GetBase(ubuf).EqAbsHeader(ubuf)
 ensures len(s.absPkt(ubuf).CurrSeg.Future) == 1
 decreases
 func (s *Raw) LastHopLemma(ubuf []byte) {
-	reveal validPktMetaHdr(ubuf)
+	validPktMetaHdr(ubuf)
 	metaHdr := RawBytesToMetaHdr(ubuf)
 	currInfIdx := int(metaHdr.CurrINF)
 	currHfIdx := int(metaHdr.CurrHF)
@@ -611,8 +601,8 @@ func (s *Raw) LastHopLemma(ubuf []byte) {
 	prevSegLen := segs.LengthOfPrevSeg(currHfIdx)
 	numINF := segs.NumInfoFields()
 	offset := HopFieldOffset(numINF, prevSegLen, MetaLen)
-	pkt := reveal s.absPkt(ubuf)
-	assert pkt.CurrSeg == reveal CurrSeg(ubuf, offset, currInfIdx, currHfIdx - prevSegLen, segLen, MetaLen)
+	pkt := s.absPkt(ubuf)
+	assert pkt.CurrSeg == CurrSeg(ubuf, offset, currInfIdx, currHfIdx - prevSegLen, segLen, MetaLen)
 	assert len(pkt.CurrSeg.Future) == 1
 }
 
@@ -628,7 +618,7 @@ ensures   len(get(s.absPkt(ubuf).LeftSeg).Future) > 0
 ensures   len(get(s.absPkt(ubuf).LeftSeg).History) == 0
 decreases
 func (s *Raw) XoverLemma(ubuf []byte) {
-	reveal validPktMetaHdr(ubuf)
+	validPktMetaHdr(ubuf)
 	metaHdr := RawBytesToMetaHdr(ubuf)
 	currInfIdx := int(metaHdr.CurrINF)
 	currHfIdx := int(metaHdr.CurrHF)
@@ -640,9 +630,9 @@ func (s *Raw) XoverLemma(ubuf []byte) {
 	prevSegLen := segs.LengthOfPrevSeg(currHfIdx)
 	numINF := segs.NumInfoFields()
 	offset := HopFieldOffset(numINF, prevSegLen, MetaLen)
-	pkt := reveal s.absPkt(ubuf)
-	assert pkt.CurrSeg == reveal CurrSeg(ubuf, offset, currInfIdx, currHfIdx - prevSegLen, segLen, MetaLen)
-	assert pkt.LeftSeg == reveal LeftSeg(ubuf, currInfIdx + 1, segs, MetaLen)
+	pkt := s.absPkt(ubuf)
+	assert pkt.CurrSeg == CurrSeg(ubuf, offset, currInfIdx, currHfIdx - prevSegLen, segLen, MetaLen)
+	assert pkt.LeftSeg == LeftSeg(ubuf, currInfIdx + 1, segs, MetaLen)
 	assert len(pkt.CurrSeg.Future) == 1
 	assert pkt.LeftSeg != none[io.Seg]
 	assert len(get(s.absPkt(ubuf).LeftSeg).History) == 0
@@ -650,7 +640,6 @@ func (s *Raw) XoverLemma(ubuf []byte) {
 }
 
 ghost
-opaque
 requires pkt.PathNotFullyTraversed()
 decreases
 pure func (s *Raw) EqAbsHopField(pkt io.Pkt, hop io.HF) bool {
@@ -659,7 +648,6 @@ pure func (s *Raw) EqAbsHopField(pkt io.Pkt, hop io.HF) bool {
 }
 
 ghost
-opaque
 decreases
 pure func (s *Raw) EqAbsInfoField(pkt io.Pkt, info io.AbsInfoField) bool {
 	return let currseg := pkt.CurrSeg in
@@ -683,7 +671,7 @@ ensures   s.EqAbsInfoField(s.absPkt(ubuf), info.ToAbsInfoField())
 ensures   s.EqAbsHopField(s.absPkt(ubuf), hop.Abs())
 decreases
 func (s *Raw) DecodingLemma(ubuf []byte, info path.InfoField, hop path.HopField) {
-	assert reveal validPktMetaHdr(ubuf)
+	assert validPktMetaHdr(ubuf)
 	metaHdr := RawBytesToMetaHdr(ubuf)
 	currInfIdx := int(metaHdr.CurrINF)
 	currHfIdx := int(metaHdr.CurrHF)
@@ -696,13 +684,13 @@ func (s *Raw) DecodingLemma(ubuf []byte, info path.InfoField, hop path.HopField)
 	numINF := segs.NumInfoFields()
 	offset := HopFieldOffset(numINF, prevSegLen, MetaLen)
 	hfIdxSeg := currHfIdx - prevSegLen
-	assert reveal s.CorrectlyDecodedInf(ubuf, info)
-	assert reveal s.CorrectlyDecodedHf(ubuf, hop)
+	assert s.CorrectlyDecodedInf(ubuf, info)
+	assert s.CorrectlyDecodedHf(ubuf, hop)
 
-	currSeg := reveal CurrSeg(ubuf, offset, currInfIdx, hfIdxSeg, segLen, MetaLen)
+	currSeg := CurrSeg(ubuf, offset, currInfIdx, hfIdxSeg, segLen, MetaLen)
 	HopsFromPrefixOfRawMatchPrefixOfHops(ubuf, offset, 0, segLen, hfIdxSeg)
 
-	pktView := reveal s.absPkt(ubuf)
+	pktView := s.absPkt(ubuf)
 	infoView := info.ToAbsInfoField()
 
 	// assertions for proving s.EqAbsInfoField(pktView, infoView)
@@ -719,8 +707,8 @@ func (s *Raw) DecodingLemma(ubuf []byte, info path.InfoField, hop path.HopField)
 		assert pktView.CurrSeg.UInfo == infoView.UInfo
 	}
 
-	assert reveal s.EqAbsInfoField(pktView, infoView)
-	assert reveal s.EqAbsHopField(pktView, hop.Abs())
+	assert s.EqAbsInfoField(pktView, infoView)
+	assert s.EqAbsHopField(pktView, hop.Abs())
 }
 
 ghost
@@ -733,7 +721,7 @@ preserves acc(sl.Bytes(raw, 0, len(raw)), R56)
 ensures   len(CurrSeg(raw, offset, currInfIdx, currHfIdx, segLen, 0).Future) > 0
 decreases
 func LenCurrSeg(raw []byte, offset int, currInfIdx int, currHfIdx int, segLen int) {
-	reveal CurrSeg(raw, offset, currInfIdx, currHfIdx, segLen, 0)
+	CurrSeg(raw, offset, currInfIdx, currHfIdx, segLen, 0)
 }
 
 ghost
@@ -747,8 +735,8 @@ ensures   LeftSeg(raw, currInfIdx + 1, segs, 0) != none[io.Seg]
 ensures   RightSeg(raw, currInfIdx, segs, 0) != none[io.Seg]
 decreases
 func XoverSegNotNone(raw []byte, currInfIdx int, segs io.SegLens) {
-	reveal LeftSeg(raw, currInfIdx + 1, segs, 0)
-	reveal RightSeg(raw, currInfIdx, segs, 0)
+	LeftSeg(raw, currInfIdx + 1, segs, 0)
+	RightSeg(raw, currInfIdx, segs, 0)
 }
 
 ghost
@@ -763,8 +751,8 @@ ensures   CurrSeg(raw, offset, currInfIdx, currHfIdx + 1, segLen, 0) ==
 	absIncPathSeg(CurrSeg(raw, offset, currInfIdx, currHfIdx, segLen, 0))
 decreases
 func IncCurrSeg(raw []byte, offset int, currInfIdx int, currHfIdx int, segLen int) {
-	currseg := reveal CurrSeg(raw, offset, currInfIdx, currHfIdx, segLen, 0)
-	incseg := reveal CurrSeg(raw, offset, currInfIdx, currHfIdx + 1, segLen, 0)
+	currseg := CurrSeg(raw, offset, currInfIdx, currHfIdx, segLen, 0)
+	incseg := CurrSeg(raw, offset, currInfIdx, currHfIdx + 1, segLen, 0)
 	hf := hopFields(raw, offset, 0, segLen)
 	hfPast := hf[:currHfIdx + 1]
 	assert hfPast[:len(hfPast) - 1] == hf[:currHfIdx]
@@ -801,8 +789,8 @@ func XoverCurrSeg(raw []byte, currInfIdx int, currHfIdx int, segs io.SegLens) {
 	segLen := segs.LengthOfCurrSeg(currHfIdx + 1)
 	numInf := segs.NumInfoFields()
 	offset := HopFieldOffset(numInf, prevSegLen, 0)
-	currseg := reveal CurrSeg(raw, offset, currInfIdx, 0, segLen, 0)
-	leftseg := reveal LeftSeg(raw, currInfIdx, segs, 0)
+	currseg := CurrSeg(raw, offset, currInfIdx, 0, segLen, 0)
+	leftseg := LeftSeg(raw, currInfIdx, segs, 0)
 	assert currseg == get(leftseg)
 }
 
@@ -815,8 +803,8 @@ ensures   LeftSeg(raw, currInfIdx, segs, 0) ==
 	MidSeg(raw, currInfIdx, segs, 0)
 decreases
 func XoverLeftSeg(raw []byte, currInfIdx int, segs io.SegLens) {
-	leftseg := reveal LeftSeg(raw, currInfIdx, segs, 0)
-	midseg := reveal MidSeg(raw, currInfIdx, segs, 0)
+	leftseg := LeftSeg(raw, currInfIdx, segs, 0)
+	midseg := MidSeg(raw, currInfIdx, segs, 0)
 	assert leftseg == midseg
 }
 
@@ -831,8 +819,8 @@ ensures   MidSeg(raw, currInfIdx + 4, segs, 0) ==
 	RightSeg(raw, currInfIdx, segs, 0)
 decreases
 func XoverMidSeg(raw []byte, currInfIdx int, segs io.SegLens) {
-	midseg := reveal MidSeg(raw, currInfIdx + 4, segs, 0)
-	rightseg := reveal RightSeg(raw, currInfIdx, segs, 0)
+	midseg := MidSeg(raw, currInfIdx + 4, segs, 0)
+	rightseg := RightSeg(raw, currInfIdx, segs, 0)
 	assert midseg == rightseg
 }
 
@@ -864,7 +852,7 @@ func XoverRightSeg(raw []byte, currInfIdx int, currHfIdx int, segs io.SegLens) {
 	IncCurrSeg(raw, offset, currInfIdx, segLen - 1, segLen)
 	currseg := CurrSeg(raw, offset, currInfIdx, segLen - 1, segLen, 0)
 	nextseg := CurrSeg(raw, offset, currInfIdx, segLen, segLen, 0)
-	rightseg := reveal RightSeg(raw, currInfIdx, segs, 0)
+	rightseg := RightSeg(raw, currInfIdx, segs, 0)
 	assert absIncPathSeg(currseg) == nextseg
 	assert nextseg == get(rightseg)
 	assert absIncPathSeg(currseg) == get(rightseg)

--- a/pkg/slayers/path/scion/widen-lemma.gobra
+++ b/pkg/slayers/path/scion/widen-lemma.gobra
@@ -70,8 +70,8 @@ func WidenCurrSeg(raw []byte,
 	assert peer1 == peer2
 
 	widenSegment(raw, offset, currHfIdx, ainfo1, uinfo1, consDir1, peer1, segLen, start, length)
-	reveal CurrSeg(raw, offset, currInfIdx, currHfIdx, segLen, headerOffset)
-	reveal CurrSeg(raw[start:length], offset-start, currInfIdx, currHfIdx, segLen, headerOffset-start)
+	CurrSeg(raw, offset, currInfIdx, currHfIdx, segLen, headerOffset)
+	CurrSeg(raw[start:length], offset-start, currInfIdx, currHfIdx, segLen, headerOffset-start)
 	fold acc(sl.Bytes(raw, 0, len(raw)), R53)
 	fold acc(sl.Bytes(raw[start:length], 0, len(raw[start:length])), R53)
 }
@@ -147,8 +147,8 @@ func WidenLeftSeg(raw []byte,
 		offsetWithHopfields := offset + path.HopLen * (segs.Seg1Len + segs.Seg2Len)
 		WidenCurrSeg(raw, offsetWithHopfields, currInfIdx, 0, segs.Seg3Len, headerOffset, start, length)
 	}
-	reveal LeftSeg(raw, currInfIdx, segs, headerOffset)
-	reveal LeftSeg(raw[start:length], currInfIdx, segs, headerOffset- start)
+	LeftSeg(raw, currInfIdx, segs, headerOffset)
+	LeftSeg(raw[start:length], currInfIdx, segs, headerOffset- start)
 }
 
 ghost
@@ -175,8 +175,8 @@ func WidenRightSeg(raw []byte,
 	} else if currInfIdx == 0 && segs.Seg2Len > 0 {
 		WidenCurrSeg(raw, offset, currInfIdx, segs.Seg1Len, segs.Seg1Len, headerOffset, start, length)
 	}
-	reveal RightSeg(raw, currInfIdx, segs, headerOffset)
-	reveal RightSeg(raw[start:length], currInfIdx, segs, headerOffset - start)
+	RightSeg(raw, currInfIdx, segs, headerOffset)
+	RightSeg(raw[start:length], currInfIdx, segs, headerOffset - start)
 }
 
 ghost
@@ -203,6 +203,6 @@ func WidenMidSeg(raw []byte,
 		offsetWithHopfields := offset + path.HopLen * (segs.Seg1Len + segs.Seg2Len)
 		WidenCurrSeg(raw, offsetWithHopfields, currInfIdx, 0, segs.Seg3Len, headerOffset, start, length)
 	}
-	reveal MidSeg(raw, currInfIdx, segs, headerOffset)
-	reveal MidSeg(raw[start:length], currInfIdx, segs, headerOffset - start)
+	MidSeg(raw, currInfIdx, segs, headerOffset)
+	MidSeg(raw[start:length], currInfIdx, segs, headerOffset - start)
 }

--- a/pkg/slayers/scion.go
+++ b/pkg/slayers/scion.go
@@ -265,7 +265,7 @@ func (s *SCION) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeO
 	binary.BigEndian.PutUint16(buf[10:12], 0)
 	// @ fold acc(sl.Bytes(uSerBufN, 0, len(uSerBufN)), writePerm)
 	// @ ghost if s.EqPathType(ubuf) {
-	// @ 	assert reveal s.EqPathTypeWithBuffer(ubuf, uSerBufN)
+	// @ 	assert s.EqPathTypeWithBuffer(ubuf, uSerBufN)
 	// @ 	s.IsSupportedPktLemma(ubuf, uSerBufN)
 	// @ }
 
@@ -310,8 +310,8 @@ func (s *SCION) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeO
 	// @ sl.Unslice_Bytes(ubuf, 0, startP, R54)
 	// @ sl.CombineRange_Bytes(uSerBufN, offset, scnLen, HalfPerm)
 	// @ sl.CombineRange_Bytes(ubuf, startP, endP, HalfPerm)
-	// @ reveal IsSupportedPkt(uSerBufN)
-	// @ reveal IsSupportedRawPkt(b.View())
+	// @ IsSupportedPkt(uSerBufN)
+	// @ IsSupportedRawPkt(b.View())
 	return tmp
 }
 
@@ -436,15 +436,15 @@ func (s *SCION) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) (res er
 	// @ 	unfold acc(sl.Bytes(data, 0, len(data)), R56)
 	// @ 	unfold acc(sl.Bytes(data[offset : offset+pathLen], 0, len(data[offset : offset+pathLen])), R56)
 	// @ 	unfold acc(s.Path.(*scion.Raw).Mem(data[offset : offset+pathLen]), R55)
-	// @ 	assert reveal s.EqAbsHeader(data)
-	// @ 	assert reveal s.ValidScionInitSpec(data)
+	// @ 	assert s.EqAbsHeader(data)
+	// @ 	assert s.ValidScionInitSpec(data)
 	// @ 	fold acc(s.Path.Mem(data[offset : offset+pathLen]), R55)
 	// @ 	fold acc(sl.Bytes(data, 0, len(data)), R56)
 	// @ 	fold acc(sl.Bytes(data[offset : offset+pathLen], 0, len(data[offset : offset+pathLen])), R56)
 	// @ }
 	// @ sl.CombineRange_Bytes(data, offset, offset+pathLen, R41)
 	// @ assert typeOf(s.GetPath(data)) == *scion.Raw ==> s.EqAbsHeader(data) && s.ValidScionInitSpec(data)
-	// @ assert reveal s.EqPathType(data)
+	// @ assert s.EqPathType(data)
 	// @ fold acc(s.Mem(data), 1-R54)
 	return nil
 }

--- a/pkg/slayers/scion_spec.gobra
+++ b/pkg/slayers/scion_spec.gobra
@@ -352,7 +352,6 @@ pure func (s *SCION) GetPath(ub []byte) path.Path {
 }
 
 ghost
-opaque
 requires s.Mem(ub)
 requires sl.Bytes(ub, 0, length)
 requires CmnHdrLen <= length
@@ -374,10 +373,10 @@ ensures  acc(sl.Bytes(ub, 0, length), R55)
 ensures  s.ValidHeaderOffset(ub, length)
 decreases
 func (s *SCION) ValidHeaderOffsetToSubSliceLemma(ub []byte, length int) {
-	reveal s.ValidHeaderOffset(ub, len(ub))
+	s.ValidHeaderOffset(ub, len(ub))
 	unfold acc(sl.Bytes(ub, 0, len(ub)), R56)
 	unfold acc(sl.Bytes(ub, 0, length), R56)
-	assert reveal s.ValidHeaderOffset(ub, length)
+	assert s.ValidHeaderOffset(ub, length)
 	fold acc(sl.Bytes(ub, 0, len(ub)), R56)
 	fold acc(sl.Bytes(ub, 0, length), R56)
 }
@@ -394,16 +393,15 @@ ensures  acc(sl.Bytes(ub, 0, length), R55)
 ensures  s.ValidHeaderOffset(ub, len(ub))
 decreases
 func (s *SCION) ValidHeaderOffsetFromSubSliceLemma(ub []byte, length int) {
-	reveal s.ValidHeaderOffset(ub, len(ub))
+	s.ValidHeaderOffset(ub, len(ub))
 	unfold acc(sl.Bytes(ub, 0, len(ub)), R56)
 	unfold acc(sl.Bytes(ub, 0, length), R56)
-	assert reveal s.ValidHeaderOffset(ub, length)
+	assert s.ValidHeaderOffset(ub, length)
 	fold acc(sl.Bytes(ub, 0, len(ub)), R56)
 	fold acc(sl.Bytes(ub, 0, length), R56)
 }
 
 ghost
-opaque
 requires s.Mem(ub)
 requires sl.Bytes(ub, 0, len(ub))
 decreases
@@ -435,7 +433,6 @@ pure func (s *SCION) EqAbsHeader(ub []byte) bool {
 
 // Describes a SCION packet that was successfully decoded by `DecodeFromBytes`.
 ghost
-opaque
 requires s.Mem(ub)
 decreases
 pure func (s *SCION) ValidScionInitSpec(ub []byte) bool {
@@ -450,7 +447,6 @@ pure func (s *SCION) ValidScionInitSpec(ub []byte) bool {
 
 // Checks if the common path header is valid in the serialized scion packet.
 ghost
-opaque
 requires sl.Bytes(raw, 0, len(raw))
 decreases
 pure func ValidPktMetaHdr(raw []byte) bool {
@@ -476,7 +472,6 @@ pure func ValidPktMetaHdr(raw []byte) bool {
 }
 
 ghost
-opaque
 requires sl.Bytes(raw, 0, len(raw))
 decreases
 pure func IsSupportedPkt(raw []byte) bool {
@@ -488,7 +483,6 @@ pure func IsSupportedPkt(raw []byte) bool {
 }
 
 ghost
-opaque
 decreases
 pure func IsSupportedRawPkt(raw seq[byte]) bool {
 	return CmnHdrLen <= len(raw) &&
@@ -507,8 +501,8 @@ decreases
 func IsSupportedPktSubslice(raw []byte, idx int) {
 	unfold acc(sl.Bytes(raw, 0, len(raw)), R56)
 	unfold acc(sl.Bytes(raw[:idx], 0, idx), R56)
-	reveal IsSupportedPkt(raw)
-	reveal IsSupportedPkt(raw[:idx])
+	IsSupportedPkt(raw)
+	IsSupportedPkt(raw[:idx])
 	fold acc(sl.Bytes(raw, 0, len(raw)), R56)
 	fold acc(sl.Bytes(raw[:idx], 0, idx), R56)
 }
@@ -522,10 +516,10 @@ preserves s.EqPathTypeWithBuffer(ub, buffer)
 ensures   IsSupportedPkt(ub) == IsSupportedPkt(buffer)
 decreases
 func (s *SCION) IsSupportedPktLemma(ub []byte, buffer []byte) {
-	reveal s.EqPathType(ub)
-	reveal s.EqPathTypeWithBuffer(ub, buffer)
-	reveal IsSupportedPkt(ub)
-	reveal IsSupportedPkt(buffer)
+	s.EqPathType(ub)
+	s.EqPathTypeWithBuffer(ub, buffer)
+	IsSupportedPkt(ub)
+	IsSupportedPkt(buffer)
 }
 
 ghost
@@ -583,16 +577,14 @@ pure func GetNextHdr(ub []byte) int {
 }
 
 ghost
-opaque
 requires s.Mem(ub)
 requires sl.Bytes(ub, 0, len(ub))
 decreases
 pure func (s *SCION) EqPathType(ub []byte) bool {
-	return reveal s.EqPathTypeWithBuffer(ub, ub)
+	return s.EqPathTypeWithBuffer(ub, ub)
 }
 
 ghost
-opaque
 requires s.Mem(ub)
 requires sl.Bytes(buffer, 0, len(buffer))
 decreases

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -814,16 +814,16 @@ func (d *DataPlane) Run(ctx context.Context /*@, ghost place io.Place, ghost sta
 	// @ ensures   d.DpAgreesWithSpec(dp)
 	// @ decreases
 	// @ outline (
-	// @ reveal d.PreWellConfigured()
-	// @ reveal d.getDomExternal()
-	// @ reveal d.DpAgreesWithSpec(dp)
+	// @ d.PreWellConfigured()
+	// @ d.getDomExternal()
+	// @ d.DpAgreesWithSpec(dp)
 	// @ unfold d.Mem()
 	d.running = true
 	// @ fold MutexInvariant!<d!>()
 	// @ fold d.Mem()
-	// @ reveal d.getDomExternal()
-	// @ reveal d.PreWellConfigured()
-	// @ reveal d.DpAgreesWithSpec(dp)
+	// @ d.getDomExternal()
+	// @ d.PreWellConfigured()
+	// @ d.DpAgreesWithSpec(dp)
 	// @ )
 	// @ ghost ioLockRun, ioSharedArgRun := InitSharedInv(dp, place, state)
 	d.initMetrics( /*@ dp @*/ )
@@ -1342,9 +1342,9 @@ func (d *DataPlane) Run(ctx context.Context /*@, ghost place io.Place, ghost sta
 // @ ensures   d.getValForwardingMetrics() != nil
 // @ decreases
 func (d *DataPlane) initMetrics( /*@ ghost dp io.DataPlaneSpec @*/ ) {
-	// @ assert reveal d.PreWellConfigured()
-	// @ reveal d.getDomExternal()
-	// @ assert reveal d.DpAgreesWithSpec(dp)
+	// @ assert d.PreWellConfigured()
+	// @ d.getDomExternal()
+	// @ assert d.DpAgreesWithSpec(dp)
 	// @ assert unfolding acc(d.Mem(), _) in
 	// @ 	d.dpSpecWellConfiguredLocalIA(dp)     &&
 	// @ 	d.dpSpecWellConfiguredNeighborIAs(dp) &&
@@ -1416,9 +1416,9 @@ func (d *DataPlane) initMetrics( /*@ ghost dp io.DataPlaneSpec @*/ ) {
 	// @ assert d.dpSpecWellConfiguredNeighborIAs(dp)
 	// @ assert d.dpSpecWellConfiguredLinkTypes(dp)
 	// @ fold d.Mem()
-	// @ reveal d.getDomExternal()
-	// @ reveal d.WellConfigured()
-	// @ assert reveal d.DpAgreesWithSpec(dp)
+	// @ d.getDomExternal()
+	// @ d.WellConfigured()
+	// @ assert d.DpAgreesWithSpec(dp)
 }
 
 type processResult struct {
@@ -1636,8 +1636,8 @@ func (p *scionPacketProcessor) processPkt(rawPkt []byte,
 		// @ }
 		// @ assert sl.Bytes(p.rawPkt, 0, len(p.rawPkt))
 		// @ unfold acc(p.d.Mem(), _)
-		// @ assert reveal p.scionLayer.EqPathType(p.rawPkt)
-		// @ assert !(reveal slayers.IsSupportedPkt(p.rawPkt))
+		// @ assert p.scionLayer.EqPathType(p.rawPkt)
+		// @ assert !(slayers.IsSupportedPkt(p.rawPkt))
 		v1, v2 /*@, aliasesPkt, newAbsPkt @*/ := p.processOHP()
 		// @ ResetDecodingLayers(&p.scionLayer, &p.hbhLayer, &p.e2eLayer, ubScionLayer, ubHbhLayer, ubE2eLayer, true, hasHbhLayer, hasE2eLayer)
 		// @ fold p.sInit()
@@ -2089,8 +2089,8 @@ func (p *scionPacketProcessor) parsePath( /*@ ghost ub []byte @*/ ) (respr proce
 	p.hopField = tmpHopField
 	// @ path.AbsMacArrayCongruence(p.hopField.Mac, tmpHopField.Mac)
 	// @ assert p.hopField.Abs() == tmpHopField.Abs()
-	// @ assert err == nil ==> reveal p.path.CorrectlyDecodedHf(ubPath, tmpHopField)
-	// @ assert err == nil ==> reveal p.path.CorrectlyDecodedHf(ubPath, p.hopField)
+	// @ assert err == nil ==> p.path.CorrectlyDecodedHf(ubPath, tmpHopField)
+	// @ assert err == nil ==> p.path.CorrectlyDecodedHf(ubPath, p.hopField)
 	// @ fold p.d.validResult(processResult{}, false)
 	if err != nil {
 		// TODO(lukedirtwalker) parameter problem invalid path?
@@ -2124,13 +2124,13 @@ func (p *scionPacketProcessor) parsePath( /*@ ghost ub []byte @*/ ) (respr proce
 	// @ p.SubSliceAbsPktToAbsPkt(ub, startP, endP)
 	// @ absPktFutureLemma(ub)
 	// @ p.path.DecodingLemma(ubPath, p.infoField, p.hopField)
-	// @ assert reveal p.path.EqAbsInfoField(p.path.absPkt(ubPath),
+	// @ assert p.path.EqAbsInfoField(p.path.absPkt(ubPath),
 	// @ 	p.infoField.ToAbsInfoField())
-	// @ assert reveal p.path.EqAbsHopField(p.path.absPkt(ubPath),
+	// @ assert p.path.EqAbsHopField(p.path.absPkt(ubPath),
 	// @ 	p.hopField.Abs())
-	// @ assert reveal p.EqAbsHopField(absPkt(ub))
-	// @ assert reveal p.EqAbsInfoField(absPkt(ub))
-	// @ assert old(reveal slayers.IsSupportedPkt(ub)) == reveal slayers.IsSupportedPkt(ub)
+	// @ assert p.EqAbsHopField(absPkt(ub))
+	// @ assert p.EqAbsInfoField(absPkt(ub))
+	// @ assert old(slayers.IsSupportedPkt(ub)) == slayers.IsSupportedPkt(ub)
 	return processResult{}, nil
 }
 
@@ -2289,9 +2289,9 @@ func (p *scionPacketProcessor) validateIngressID( /*@ ghost ubScionL []byte, gho
 		return tmpRes, tmpErr
 	}
 	// @ ghost oldPkt := absPkt(ubScionL)
-	// @ reveal p.EqAbsHopField(oldPkt)
-	// @ reveal p.EqAbsInfoField(oldPkt)
-	// @ assert reveal AbsValidateIngressIDConstraint(oldPkt, path.ifsToIO_ifs(p.ingressID))
+	// @ p.EqAbsHopField(oldPkt)
+	// @ p.EqAbsInfoField(oldPkt)
+	// @ assert AbsValidateIngressIDConstraint(oldPkt, path.ifsToIO_ifs(p.ingressID))
 	// @ fold p.d.validResult(respr, false)
 	return processResult{}, nil
 }
@@ -2387,8 +2387,8 @@ func (p *scionPacketProcessor) validateSrcDstIA( /*@ ghost ubScionL []byte, ghos
 	// @ assert  (unfolding acc(p.scionLayer.Mem(ubScionL), R55) in
 	// @ 	(unfolding acc(p.scionLayer.HeaderMem(ubScionL[slayers.CmnHdrLen:]), R55) in
 	// @ 	p.scionLayer.DstIA) == (unfolding acc(p.d.Mem(), _) in p.d.localIA)) ==> p.path.IsLastHopSpec(ubPath)
-	// @ assert reveal p.DstIsLocalIngressID(ubScionL)
-	// @ assert reveal p.LastHopLen(ubScionL)
+	// @ assert p.DstIsLocalIngressID(ubScionL)
+	// @ assert p.LastHopLen(ubScionL)
 	// @ ghost sl.CombineRange_Bytes(ubScionL, startP, endP, R50)
 	return processResult{}, nil
 }
@@ -2623,7 +2623,7 @@ func (p *scionPacketProcessor) validateTransitUnderlaySrc( /*@ ghost ub []byte @
 func (p *scionPacketProcessor) validateEgressID( /*@ ghost dp io.DataPlaneSpec, ghost ubScionL []byte, ghost ubLL []byte, ghost startLL int, ghost endLL int @*/ ) (respr processResult, reserr error) {
 	// @ ghost oldPkt := absPkt(ubScionL)
 	pktEgressID := p.egressInterface( /*@ oldPkt @*/ )
-	// @ reveal AbsEgressInterfaceConstraint(oldPkt, path.ifsToIO_ifs(pktEgressID))
+	// @ AbsEgressInterfaceConstraint(oldPkt, path.ifsToIO_ifs(pktEgressID))
 	// @ p.d.getInternalNextHops()
 	// @ if p.d.internalNextHops != nil { unfold acc(accAddr(p.d.internalNextHops), _) }
 	_, ih := p.d.internalNextHops[pktEgressID]
@@ -2659,22 +2659,22 @@ func (p *scionPacketProcessor) validateEgressID( /*@ ghost dp io.DataPlaneSpec, 
 	if !p.segmentChange {
 		// Check that the interface pair is valid within a single segment.
 		// No check required if the packet is received from an internal interface.
-		// @ assert reveal AbsValidateIngressIDConstraint(oldPkt, path.ifsToIO_ifs(p.ingressID))
+		// @ assert AbsValidateIngressIDConstraint(oldPkt, path.ifsToIO_ifs(p.ingressID))
 		switch {
 		case p.ingressID == 0:
-			// @ assert reveal AbsValidateEgressIDConstraint(oldPkt, (p.ingressID != 0), dp)
+			// @ assert AbsValidateEgressIDConstraint(oldPkt, (p.ingressID != 0), dp)
 			// @ fold p.d.validResult(respr, false)
 			return processResult{}, nil
 		case ingress == topology.Core && egress == topology.Core:
-			// @ assert reveal AbsValidateEgressIDConstraint(oldPkt, (p.ingressID != 0), dp)
+			// @ assert AbsValidateEgressIDConstraint(oldPkt, (p.ingressID != 0), dp)
 			// @ fold p.d.validResult(respr, false)
 			return processResult{}, nil
 		case ingress == topology.Child && egress == topology.Parent:
-			// @ assert reveal AbsValidateEgressIDConstraint(oldPkt, (p.ingressID != 0), dp)
+			// @ assert AbsValidateEgressIDConstraint(oldPkt, (p.ingressID != 0), dp)
 			// @ fold p.d.validResult(respr, false)
 			return processResult{}, nil
 		case ingress == topology.Parent && egress == topology.Child:
-			// @ assert reveal AbsValidateEgressIDConstraint(oldPkt, (p.ingressID != 0), dp)
+			// @ assert AbsValidateEgressIDConstraint(oldPkt, (p.ingressID != 0), dp)
 			// @ fold p.d.validResult(respr, false)
 			return processResult{}, nil
 		default: // malicious
@@ -2692,20 +2692,20 @@ func (p *scionPacketProcessor) validateEgressID( /*@ ghost dp io.DataPlaneSpec, 
 			return tmpRes, tmpErr
 		}
 	}
-	// @ assert reveal AbsValidateIngressIDConstraintXover(oldPkt, path.ifsToIO_ifs(p.ingressID))
+	// @ assert AbsValidateIngressIDConstraintXover(oldPkt, path.ifsToIO_ifs(p.ingressID))
 	// Check that the interface pair is valid on a segment switch.
 	// Having a segment change received from the internal interface is never valid.
 	switch {
 	case ingress == topology.Core && egress == topology.Child:
-		// @ assert reveal AbsValidateEgressIDConstraintXover(oldPkt, dp)
+		// @ assert AbsValidateEgressIDConstraintXover(oldPkt, dp)
 		// @ fold p.d.validResult(respr, false)
 		return processResult{}, nil
 	case ingress == topology.Child && egress == topology.Core:
-		// @ assert reveal AbsValidateEgressIDConstraintXover(oldPkt, dp)
+		// @ assert AbsValidateEgressIDConstraintXover(oldPkt, dp)
 		// @ fold p.d.validResult(respr, false)
 		return processResult{}, nil
 	case ingress == topology.Child && egress == topology.Child:
-		// @ assert reveal AbsValidateEgressIDConstraintXover(oldPkt, dp)
+		// @ assert AbsValidateEgressIDConstraintXover(oldPkt, dp)
 		// @ fold p.d.validResult(respr, false)
 		return processResult{}, nil
 	default:
@@ -2768,11 +2768,11 @@ func (p *scionPacketProcessor) updateNonConsDirIngressSegID( /*@ ghost ub []byte
 	// means this comes from this AS itself, so nothing has to be done.
 	// TODO(lukedirtwalker): For packets destined to peer links this shouldn't
 	// be updated.
-	// @ reveal p.EqAbsInfoField(absPkt(ub))
-	// @ reveal p.EqAbsHopField(absPkt(ub))
+	// @ p.EqAbsInfoField(absPkt(ub))
+	// @ p.EqAbsHopField(absPkt(ub))
 	if !p.infoField.ConsDir && p.ingressID != 0 {
 		p.infoField.UpdateSegID(p.hopField.Mac /*@, p.hopField.Abs() @*/)
-		// @ reveal p.LastHopLen(ub)
+		// @ p.LastHopLen(ub)
 		// @ assert path.AbsUInfoFromUint16(p.infoField.SegID) ==
 		// @ 	old(io.upd_uinfo(path.AbsUInfoFromUint16(p.infoField.SegID), p.hopField.Abs()))
 		// (VerifiedSCION) the following property is guaranteed by the type system, but Gobra cannot infer it yet
@@ -2800,11 +2800,11 @@ func (p *scionPacketProcessor) updateNonConsDirIngressSegID( /*@ ghost ub []byte
 		// @ absPktFutureLemma(ub)
 		// @ assert absPkt(ub).CurrSeg.UInfo ==
 		// @ 	old(io.upd_uinfo(path.AbsUInfoFromUint16(p.infoField.SegID), p.hopField.Abs()))
-		// @ assert reveal p.EqAbsInfoField(absPkt(ub))
-		// @ assert reveal p.EqAbsHopField(absPkt(ub))
-		// @ assert reveal p.LastHopLen(ub)
+		// @ assert p.EqAbsInfoField(absPkt(ub))
+		// @ assert p.EqAbsHopField(absPkt(ub))
+		// @ assert p.LastHopLen(ub)
 	}
-	// @ assert absPkt(ub) == reveal AbsUpdateNonConsDirIngressSegID(old(absPkt(ub)), path.ifsToIO_ifs(p.ingressID))
+	// @ assert absPkt(ub) == AbsUpdateNonConsDirIngressSegID(old(absPkt(ub)), path.ifsToIO_ifs(p.ingressID))
 	return nil
 }
 
@@ -2935,13 +2935,13 @@ func (p *scionPacketProcessor) verifyCurrentMAC( /*@ ghost dp io.DataPlaneSpec, 
 	// Add the full MAC to the SCION packet processor,
 	// such that EPIC does not need to recalculate it.
 	p.cachedMac = fullMac
-	// @ reveal p.EqAbsInfoField(oldPkt)
-	// @ reveal p.EqAbsHopField(oldPkt)
+	// @ p.EqAbsInfoField(oldPkt)
+	// @ p.EqAbsHopField(oldPkt)
 	// (VerifiedSCION) Assumptions for Cryptography:
 	// @ absInf := p.infoField.ToAbsInfoField()
 	// @ absHF := p.hopField.Abs()
 	// @ AssumeForIO(dp.hf_valid(absInf.ConsDir, absInf.AInfo.V, absInf.UInfo, absHF))
-	// @ reveal AbsVerifyCurrentMACConstraint(oldPkt, dp)
+	// @ AbsVerifyCurrentMACConstraint(oldPkt, dp)
 	// @ fold p.d.validResult(processResult{}, false)
 	return processResult{}, nil
 }
@@ -3056,10 +3056,10 @@ func (p *scionPacketProcessor) processEgress( /*@ ghost ub []byte @*/ ) (reserr 
 	// @ slayers.IsSupportedPktSubslice(ub, slayers.CmnHdrLen)
 	// @ p.AbsPktToSubSliceAbsPkt(ub, startP, endP)
 	// @ p.scionLayer.ValidHeaderOffsetToSubSliceLemma(ub, startP)
-	// @ reveal p.EqAbsInfoField(absPkt(ub))
-	// @ reveal p.EqAbsHopField(absPkt(ub))
+	// @ p.EqAbsInfoField(absPkt(ub))
+	// @ p.EqAbsHopField(absPkt(ub))
 	// @ sl.SplitRange_Bytes(ub, startP, endP, HalfPerm)
-	// @ reveal p.scionLayer.ValidHeaderOffset(ub, startP)
+	// @ p.scionLayer.ValidHeaderOffset(ub, startP)
 	// @ unfold acc(p.scionLayer.Mem(ub), R55)
 	// we are the egress router and if we go in construction direction we
 	// need to update the SegID.
@@ -3091,7 +3091,7 @@ func (p *scionPacketProcessor) processEgress( /*@ ghost ub []byte @*/ ) (reserr 
 		return serrors.WrapStr("incrementing path", err)
 	}
 	// @ fold acc(p.scionLayer.Mem(ub), R55)
-	// @ assert reveal p.scionLayer.ValidHeaderOffset(ub, startP)
+	// @ assert p.scionLayer.ValidHeaderOffset(ub, startP)
 	// @ ghost sl.CombineRange_Bytes(ub, startP, endP, HalfPerm)
 	// @ slayers.IsSupportedPktSubslice(ub, slayers.CmnHdrLen)
 	// @ sl.Unslice_Bytes(ub, 0, slayers.CmnHdrLen, R54)
@@ -3100,7 +3100,7 @@ func (p *scionPacketProcessor) processEgress( /*@ ghost ub []byte @*/ ) (reserr 
 	// @ p.SubSliceAbsPktToAbsPkt(ub, startP, endP)
 	// @ ghost sl.CombineRange_Bytes(ub, startP, endP, HalfPerm)
 	// @ absPktFutureLemma(ub)
-	// @ assert absPkt(ub) == reveal AbsProcessEgress(old(absPkt(ub)))
+	// @ assert absPkt(ub) == AbsProcessEgress(old(absPkt(ub)))
 	// @ fold acc(p.scionLayer.Mem(ub), 1-R55)
 	return nil
 }
@@ -3168,10 +3168,10 @@ func (p *scionPacketProcessor) doXover( /*@ ghost ub []byte, ghost currBase scio
 	// @ p.scionLayer.ValidHeaderOffsetToSubSliceLemma(ub, startP)
 	// @ ghost preAbsPkt := p.path.absPkt(ubPath)
 	// @ p.path.XoverLemma(ubPath)
-	// @ reveal p.EqAbsInfoField(absPkt(ub))
-	// @ reveal p.EqAbsHopField(absPkt(ub))
+	// @ p.EqAbsInfoField(absPkt(ub))
+	// @ p.EqAbsHopField(absPkt(ub))
 	// @ sl.SplitRange_Bytes(ub, startP, endP, HalfPerm)
-	// @ reveal p.scionLayer.ValidHeaderOffset(ub, startP)
+	// @ p.scionLayer.ValidHeaderOffset(ub, startP)
 	// @ unfold acc(p.scionLayer.Mem(ub), R55)
 	// @ assert p.path.GetBase(ubPath) == currBase
 	// @ ghost nextBase := currBase.IncPathSpec()
@@ -3189,7 +3189,7 @@ func (p *scionPacketProcessor) doXover( /*@ ghost ub []byte, ghost currBase scio
 	// @ assert p.path.GetBase(ubPath) == nextBase
 	// @ assert p.path.absPkt(ubPath) == scion.AbsXover(preAbsPkt)
 	// @ fold acc(p.scionLayer.Mem(ub), R55)
-	// @ assert reveal p.scionLayer.ValidHeaderOffset(ub, startP)
+	// @ assert p.scionLayer.ValidHeaderOffset(ub, startP)
 	// @ ghost sl.CombineRange_Bytes(ub, startP, endP, HalfPerm)
 	// @ slayers.IsSupportedPktSubslice(ub, slayers.CmnHdrLen)
 	// @ sl.Unslice_Bytes(ub, 0, slayers.CmnHdrLen, R54)
@@ -3205,7 +3205,7 @@ func (p *scionPacketProcessor) doXover( /*@ ghost ub []byte, ghost currBase scio
 	// @ assert len(get(old(absPkt(ub)).LeftSeg).Future) > 0
 	// @ assert len(get(old(absPkt(ub)).LeftSeg).History) == 0
 	// @ assert slayers.ValidPktMetaHdr(ub) && p.scionLayer.EqAbsHeader(ub)
-	// @ assert absPkt(ub) == reveal AbsDoXover(old(absPkt(ub)))
+	// @ assert absPkt(ub) == AbsDoXover(old(absPkt(ub)))
 	// @ assert p.path == p.scionLayer.GetPath(ub)
 	// @ assert p.path.GetBase(ubPath) == nextBase
 	var err error
@@ -3223,8 +3223,8 @@ func (p *scionPacketProcessor) doXover( /*@ ghost ub []byte, ghost currBase scio
 	p.hopField = tmpHopField
 	// @ path.AbsMacArrayCongruence(p.hopField.Mac, tmpHopField.Mac)
 	// @ assert p.hopField.Abs() == tmpHopField.Abs()
-	// @ assert reveal p.path.CorrectlyDecodedHf(ubPath, tmpHopField)
-	// @ assert reveal p.path.CorrectlyDecodedHf(ubPath, p.hopField)
+	// @ assert p.path.CorrectlyDecodedHf(ubPath, tmpHopField)
+	// @ assert p.path.CorrectlyDecodedHf(ubPath, p.hopField)
 	if p.infoField, err = p.path.GetCurrentInfoField( /*@ ubPath @*/ ); err != nil {
 		// @ ghost sl.CombineRange_Bytes(ub, startP, endP, HalfPerm)
 		// @ fold acc(p.scionLayer.Mem(ub), 1-R55)
@@ -3237,10 +3237,10 @@ func (p *scionPacketProcessor) doXover( /*@ ghost ub []byte, ghost currBase scio
 	// @ ghost sl.CombineRange_Bytes(ub, startP, endP, HalfPerm/2)
 	// @ absPktFutureLemma(ub)
 	// @ p.path.DecodingLemma(ubPath, p.infoField, p.hopField)
-	// @ assert reveal p.path.EqAbsInfoField(p.path.absPkt(ubPath), p.infoField.ToAbsInfoField())
-	// @ assert reveal p.path.EqAbsHopField(p.path.absPkt(ubPath), p.hopField.Abs())
-	// @ assert reveal p.EqAbsHopField(absPkt(ub))
-	// @ assert reveal p.EqAbsInfoField(absPkt(ub))
+	// @ assert p.path.EqAbsInfoField(p.path.absPkt(ubPath), p.infoField.ToAbsInfoField())
+	// @ assert p.path.EqAbsHopField(p.path.absPkt(ubPath), p.hopField.Abs())
+	// @ assert p.EqAbsHopField(absPkt(ub))
+	// @ assert p.EqAbsInfoField(absPkt(ub))
 	// @ ghost sl.CombineRange_Bytes(ub, startP, endP, HalfPerm/2)
 	// @ fold acc(p.scionLayer.Mem(ub), 1-R55)
 	// @ assert currBase.IncPathSpec().Valid()
@@ -3291,13 +3291,13 @@ func (p *scionPacketProcessor) ingressInterface( /*@ ghost ubPath []byte @*/ ) u
 // @ ensures  AbsEgressInterfaceConstraint(oldPkt, path.ifsToIO_ifs(egress))
 // @ decreases
 func (p *scionPacketProcessor) egressInterface( /*@ ghost oldPkt io.Pkt @*/ ) (egress uint16) {
-	// @ reveal p.EqAbsInfoField(oldPkt)
-	// @ reveal p.EqAbsHopField(oldPkt)
+	// @ p.EqAbsInfoField(oldPkt)
+	// @ p.EqAbsHopField(oldPkt)
 	if p.infoField.ConsDir {
-		// @ assert reveal AbsEgressInterfaceConstraint(oldPkt, path.ifsToIO_ifs(p.hopField.ConsEgress))
+		// @ assert AbsEgressInterfaceConstraint(oldPkt, path.ifsToIO_ifs(p.hopField.ConsEgress))
 		return p.hopField.ConsEgress
 	}
-	// @ assert reveal AbsEgressInterfaceConstraint(oldPkt, path.ifsToIO_ifs(p.hopField.ConsIngress))
+	// @ assert AbsEgressInterfaceConstraint(oldPkt, path.ifsToIO_ifs(p.hopField.ConsIngress))
 	return p.hopField.ConsIngress
 }
 
@@ -3439,7 +3439,7 @@ func (p *scionPacketProcessor) validateEgressUp(
 // @ 	absIO_val(respr.OutPkt, respr.EgressID).isValUnsupported
 // @ decreases
 func (p *scionPacketProcessor) handleIngressRouterAlert( /*@ ghost ub []byte, ghost ubLL []byte, ghost startLL int, ghost endLL int @*/ ) (respr processResult, reserr error) {
-	// @ reveal p.EqAbsHopField(absPkt(ub))
+	// @ p.EqAbsHopField(absPkt(ub))
 	// @ assert let fut := absPkt(ub).CurrSeg.Future in
 	// @ 	fut == seq[io.HF]{p.hopField.Abs()} ++ fut[1:]
 	// @ ghost ubPath := p.scionLayer.UBPath(ub)
@@ -3459,7 +3459,7 @@ func (p *scionPacketProcessor) handleIngressRouterAlert( /*@ ghost ub []byte, gh
 	// @ unfold acc(p.scionLayer.Mem(ub), R20)
 	// (VerifiedSCION) the following is guaranteed by the type system, but Gobra cannot prove it yet
 	// @ assume 0 <= p.path.GetCurrHF(ubPath)
-	// @ reveal p.LastHopLen(ub)
+	// @ p.LastHopLen(ub)
 	// @ sl.SplitRange_Bytes(ub, startP, endP, HalfPerm)
 	// @ sl.SplitByIndex_Bytes(ub, 0, startP, slayers.CmnHdrLen, R54)
 	// @ sl.Reslice_Bytes(ub, 0, slayers.CmnHdrLen, R54)
@@ -3482,8 +3482,8 @@ func (p *scionPacketProcessor) handleIngressRouterAlert( /*@ ghost ub []byte, gh
 	// @ p.scionLayer.ValidHeaderOffsetFromSubSliceLemma(ub, startP)
 	// @ p.SubSliceAbsPktToAbsPkt(ub, startP, endP)
 	// @ absPktFutureLemma(ub)
-	// @ assert reveal p.EqAbsHopField(absPkt(ub))
-	// @ assert reveal p.LastHopLen(ub)
+	// @ assert p.EqAbsHopField(absPkt(ub))
+	// @ assert p.LastHopLen(ub)
 	// @ assert p.scionLayer.EqAbsHeader(ub)
 	// @ sl.CombineRange_Bytes(ub, startP, endP, HalfPerm)
 	// @ fold acc(p.scionLayer.Mem(ub), R20)
@@ -3552,7 +3552,7 @@ func (p *scionPacketProcessor) ingressRouterAlertFlag() (res *bool) {
 // @ 	absIO_val(respr.OutPkt, respr.EgressID).isValUnsupported
 // @ decreases
 func (p *scionPacketProcessor) handleEgressRouterAlert( /*@ ghost ub []byte, ghost ubLL []byte, ghost startLL int, ghost endLL int @*/ ) (respr processResult, reserr error) {
-	// @ reveal p.EqAbsHopField(absPkt(ub))
+	// @ p.EqAbsHopField(absPkt(ub))
 	// @ assert let fut := absPkt(ub).CurrSeg.Future in
 	// @ 	fut == seq[io.HF]{p.hopField.Abs()} ++ fut[1:]
 	// @ ghost ubPath := p.scionLayer.UBPath(ub)
@@ -3599,8 +3599,8 @@ func (p *scionPacketProcessor) handleEgressRouterAlert( /*@ ghost ub []byte, gho
 	// @ p.scionLayer.ValidHeaderOffsetFromSubSliceLemma(ub, startP)
 	// @ p.SubSliceAbsPktToAbsPkt(ub, startP, endP)
 	// @ absPktFutureLemma(ub)
-	// @ assert reveal p.EqAbsHopField(absPkt(ub))
-	// @ assert reveal p.EqAbsInfoField(absPkt(ub))
+	// @ assert p.EqAbsHopField(absPkt(ub))
+	// @ assert p.EqAbsInfoField(absPkt(ub))
 	// @ sl.CombineRange_Bytes(ub, startP, endP, HalfPerm)
 	// @ fold acc(p.scionLayer.Mem(ub), R20)
 	return p.handleSCMPTraceRouteRequest(egressID /*@, ub, ubLL, startLL, endLL @*/)
@@ -3948,7 +3948,7 @@ func (p *scionPacketProcessor) process(
 		// @ ghost if(slayers.IsSupportedPkt(ub)) {
 		// @ 	InternalEnterEvent(oldPkt, path.ifsToIO_ifs(p.ingressID), nextPkt, none[io.Ifs], ioLock, ioSharedArg, dp)
 		// @ }
-		// @ newAbsPkt = reveal absIO_val(p.rawPkt, 0)
+		// @ newAbsPkt = absIO_val(p.rawPkt, 0)
 		return processResult{OutConn: p.d.internal, OutAddr: a, OutPkt: p.rawPkt}, nil /*@, aliasesUb, newAbsPkt @*/
 	}
 	// Outbound: pkts leaving the local IA.
@@ -4022,7 +4022,7 @@ func (p *scionPacketProcessor) process(
 		// @ 		XoverEvent(oldPkt, path.ifsToIO_ifs(p.ingressID), nextPkt, path.ifsToIO_ifs(egressID), ioLock, ioSharedArg, dp)
 		// @ 	}
 		// @ }
-		// @ newAbsPkt = reveal absIO_val(p.rawPkt, egressID)
+		// @ newAbsPkt = absIO_val(p.rawPkt, egressID)
 		// @ fold p.d.validResult(processResult{EgressID: egressID, OutConn: c, OutPkt: p.rawPkt}, false)
 		return processResult{EgressID: egressID, OutConn: c, OutPkt: p.rawPkt}, nil /*@, false, newAbsPkt @*/
 	}
@@ -4040,7 +4040,7 @@ func (p *scionPacketProcessor) process(
 		// @ 		XoverEvent(oldPkt, path.ifsToIO_ifs(p.ingressID), nextPkt, none[io.Ifs], ioLock, ioSharedArg, dp)
 		// @ 	}
 		// @ }
-		// @ newAbsPkt = reveal absIO_val(p.rawPkt, 0)
+		// @ newAbsPkt = absIO_val(p.rawPkt, 0)
 		// @ fold p.d.validResult(processResult{OutConn: p.d.internal, OutAddr: a, OutPkt: p.rawPkt}, false)
 		return processResult{OutConn: p.d.internal, OutAddr: a, OutPkt: p.rawPkt}, nil /*@, false, newAbsPkt @*/
 	}
@@ -4172,13 +4172,13 @@ func (p *scionPacketProcessor) processOHP() (respr processResult, reserr error /
 			return processResult{}, serrors.New("MAC", "expected", fmt.Sprintf("%x", macCopy),
 				"actual", fmt.Sprintf("%x", ohp.FirstHop.Mac), "type", "ohp") /*@ , false, absReturnErr(processResult{}) @*/
 		}
-		// @ assert reveal p.scionLayer.EqPathType(p.rawPkt)
+		// @ assert p.scionLayer.EqPathType(p.rawPkt)
 		// @ unfold acc(p.scionLayer.Mem(ubScionL), 1-R15)
 		// @ unfold acc(s.Path.Mem(ubPath), 1-R50)
 		ohp.Info.UpdateSegID(ohp.FirstHop.Mac /*@, ohp.FirstHop.Abs() @*/)
 		// @ fold acc(s.Path.Mem(ubPath), 1-R50)
 		// @ fold acc(p.scionLayer.Mem(ubScionL), 1-R15)
-		// @ assert reveal p.scionLayer.EqPathType(p.rawPkt)
+		// @ assert p.scionLayer.EqPathType(p.rawPkt)
 
 		// (VerifiedSCION) the second parameter was changed from 's' to 'p.scionLayer' due to the
 		// changes made to 'updateSCIONLayer'.
@@ -4195,7 +4195,7 @@ func (p *scionPacketProcessor) processOHP() (respr processResult, reserr error /
 			// @ p.d.InDomainExternalInForwardingMetrics(ohp.FirstHop.ConsEgress)
 			// @ fold p.d.validResult(processResult{EgressID: ohp.FirstHop.ConsEgress, OutConn: c, OutPkt: p.rawPkt}, false)
 			return processResult{EgressID: ohp.FirstHop.ConsEgress, OutConn: c, OutPkt: p.rawPkt},
-				nil /*@ , false, reveal absIO_val(respr.OutPkt, respr.EgressID) @*/
+				nil /*@ , false, absIO_val(respr.OutPkt, respr.EgressID) @*/
 		}
 		// TODO parameter problem invalid interface
 		// @ establishCannotRoute()
@@ -4221,7 +4221,7 @@ func (p *scionPacketProcessor) processOHP() (respr processResult, reserr error /
 			"type", "ohp", "ingress", p.ingressID,
 			"neighborIA", neighborIA, "srcIA", s.SrcIA) /*@ , false, absReturnErr(processResult{}) @*/
 	}
-	// @ assert reveal p.scionLayer.EqPathType(p.rawPkt)
+	// @ assert p.scionLayer.EqPathType(p.rawPkt)
 	// @ unfold acc(p.scionLayer.Mem(ubScionL), 1-R15)
 	// @ unfold s.Path.Mem(ubPath)
 	// @ unfold ohp.SecondHop.Mem()
@@ -4239,7 +4239,7 @@ func (p *scionPacketProcessor) processOHP() (respr processResult, reserr error /
 	// @ fold ohp.SecondHop.Mem()
 	// @ fold s.Path.Mem(ubPath)
 	// @ fold acc(p.scionLayer.Mem(ubScionL), 1-R15)
-	// @ assert reveal p.scionLayer.EqPathType(p.rawPkt)
+	// @ assert p.scionLayer.EqPathType(p.rawPkt)
 
 	// (VerifiedSCION) the second parameter was changed from 's' to 'p.scionLayer' due to the
 	// changes made to 'updateSCIONLayer'.
@@ -4260,7 +4260,7 @@ func (p *scionPacketProcessor) processOHP() (respr processResult, reserr error /
 	// @ p.d.getInternal()
 	// @ assert p.d.internal != nil ==> acc(p.d.internal.Mem(), _)
 	// @ fold p.d.validResult(processResult{OutConn: p.d.internal, OutAddr: a, OutPkt: p.rawPkt}, addrAliases)
-	return processResult{OutConn: p.d.internal, OutAddr: a, OutPkt: p.rawPkt}, nil /*@ , addrAliases, reveal absIO_val(respr.OutPkt, 0) @*/
+	return processResult{OutConn: p.d.internal, OutAddr: a, OutPkt: p.rawPkt}, nil /*@ , addrAliases, absIO_val(respr.OutPkt, 0) @*/
 }
 
 // @ requires  acc(d.Mem(), _)
@@ -4368,12 +4368,12 @@ func updateSCIONLayer(rawPkt []byte, s *slayers.SCION, buffer gopacket.Serialize
 	if err := s.SerializeTo(buffer, gopacket.SerializeOptions{} /*@ , rawPkt @*/); err != nil {
 		return err
 	}
-	// @ reveal slayers.IsSupportedRawPkt(buffer.View())
+	// @ slayers.IsSupportedRawPkt(buffer.View())
 	// TODO(lukedirtwalker): We should add a method to the scion layers
 	// which can write into the existing buffer, see also the discussion in
 	// https://fsnets.slack.com/archives/C8ADBBG0J/p1592805884250700
 	rawContents := buffer.Bytes()
-	// @ assert !(reveal slayers.IsSupportedPkt(rawContents))
+	// @ assert !(slayers.IsSupportedPkt(rawContents))
 	// @ s.ValidSizeOhpUb(rawPkt)
 	// @ assert len(rawContents) <= len(rawPkt)
 	// @ unfold sl.Bytes(rawPkt, 0, len(rawPkt))
@@ -4386,7 +4386,7 @@ func updateSCIONLayer(rawPkt []byte, s *slayers.SCION, buffer gopacket.Serialize
 	copy(rawPkt[:len(rawContents)], rawContents /*@ , R20 @*/)
 	// @ fold sl.Bytes(rawPkt, 0, len(rawPkt))
 	// @ fold acc(sl.Bytes(rawContents, 0, len(rawContents)), R20)
-	// @ assert !(reveal slayers.IsSupportedPkt(rawPkt))
+	// @ assert !(slayers.IsSupportedPkt(rawPkt))
 	return nil
 }
 

--- a/router/dataplane_concurrency_model.gobra
+++ b/router/dataplane_concurrency_model.gobra
@@ -101,7 +101,6 @@ pure func MultiReadBioCorrectIfs(
 }
 
 ghost
-opaque
 requires 0 <= expectedPkts && MultiReadBio(t, expectedPkts)
 ensures len(res) == expectedPkts
 decreases expectedPkts
@@ -185,7 +184,7 @@ func MultiUpdateElemWitness(
 	}
 
 	if 0 <= n && MultiReadBioCorrectIfs(t, n, k) {
-		reveal MultiReadBioIO_val(t, n)
+		MultiReadBioIO_val(t, n)
 		fold MultiElemWitness(y.IBufY, k, MultiReadBioIO_val(t, n))
 	}
 }
@@ -351,7 +350,7 @@ ensures let d := dictMax(d1, d2) in
 	forall k Key, v io.Pkt :: !keyInDict(d, k, v) == !(keyInDict(d1, k, v) || keyInDict(d2, k, v))
 decreases
 func dictMaxAssocLemma0(d1 dict[Key]Val, d2 dict[Key]Val) {
-	reveal dictUnion(d1, d2)
+	dictUnion(d1, d2)
 }
 
 ghost
@@ -621,7 +620,6 @@ func InitElemAuth(m dict[Key]Val) (y ElemRA) {
 /////////////////////////////////////// Dict Ops ///////////////////////////////////////
 
 ghost
-opaque
 ensures dictLessThan(d1, res) && dictLessThan(d2, res)
 decreases
 pure func dictUnion(d1 dict[Key]Val, d2 dict[Key]Val) (res dict[Key]Val) {
@@ -640,7 +638,6 @@ pure func dictUnionAux(d1 dict[Key]Val, d2 dict[Key]Val) (res dict[Key]Val) {
 }
 
 ghost
-opaque
 requires visitedKeys union (domain(d1) union domain(d2)) === (domain(d1) union domain(d2))
 ensures  domain(res) === (domain(d1) union domain(d2)) setminus visitedKeys
 ensures  forall k Key :: k elem domain(res) && k elem domain(d1) && k elem domain(d2) ==> k elem domain(res) && res[k] == AsSet(d1[k]) union AsSet(d2[k])
@@ -662,8 +659,8 @@ ghost
 ensures dictUnion(d1, d2) === dictUnion(d2, d1)
 decreases
 func dictUnionIsComm(d1 dict[Key]Val, d2 dict[Key]Val) {
-	u1 := reveal dictUnion(d1, d2)
-	u2 := reveal dictUnion(d2, d1)
+	u1 := dictUnion(d1, d2)
+	u2 := dictUnion(d2, d1)
 	assert domain(u1) === domain(u2)
 	assert forall k Key :: k elem domain(u1) ==> u1[k] == u2[k]
 }
@@ -673,8 +670,8 @@ ghost
 ensures  dictLessThan(d1, d3) && dictLessThan(d2, d3) ==> dictLessThan(dictUnion(d1, d2), d3)
 decreases
 pure func dictUnionIsLessThan(d1 dict[Key]Val, d2 dict[Key]Val, d3 dict[Key]Val) U {
-	return let u1 := reveal dictUnion(d1, d2) in
-		let u2 := reveal dictUnion(d2, d1) in
+	return let u1 := dictUnion(d1, d2) in
+		let u2 := dictUnion(d2, d1) in
 		let _ := domain(u1) === domain(u2) in
 		let _ := forall k Key :: k elem domain(u1) ==> u1[k] == u2[k] in
 		U{}

--- a/router/dataplane_spec.gobra
+++ b/router/dataplane_spec.gobra
@@ -246,7 +246,6 @@ pure func (d *DataPlane) GetDomInternalNextHops() set[uint16] {
 }
 
 ghost
-opaque
 requires d.Mem()
 decreases
 pure func (d *DataPlane) getDomExternal() set[uint16] {
@@ -276,7 +275,6 @@ pure func (d *DataPlane) getDomLinkTypes() set[uint16] {
 }
 
 ghost
-opaque
 requires d.Mem()
 decreases
 pure func (d *DataPlane) WellConfigured() bool {
@@ -287,7 +285,6 @@ pure func (d *DataPlane) WellConfigured() bool {
 }
 
 ghost
-opaque
 requires d.Mem()
 decreases
 pure func (d *DataPlane) PreWellConfigured() bool {
@@ -436,7 +433,6 @@ pure func (d *DataPlane) IsRunning() bool {
 }
 
 ghost
-opaque
 requires d.Mem()
 requires acc(&d.running)
 ensures  d.IsRunning() == d.running
@@ -463,7 +459,6 @@ pure func (d *DataPlane) MetricsAreSet() bool {
 }
 
 ghost
-opaque
 requires d.Mem()
 requires acc(&d.internal)
 ensures  d.InternalConnIsSet() == (d.internal != nil)
@@ -482,7 +477,6 @@ pure func (d *DataPlane) KeyIsSet() bool {
 }
 
 ghost
-opaque
 requires d.Mem()
 requires acc(&d.macFactory)
 ensures  d.KeyIsSet() == (d.macFactory != nil)
@@ -685,7 +679,7 @@ ensures  acc(d.Mem(), _)
 ensures  id elem d.getDomForwardingMetrics()
 decreases
 func (d *DataPlane) InDomainExternalInForwardingMetrics(id uint16) {
-	reveal d.WellConfigured()
+	d.WellConfigured()
 }
 
 ghost
@@ -697,8 +691,8 @@ ensures  acc(&d.external, _) && acc(d.external, R55)
 ensures  id elem d.getDomForwardingMetrics()
 decreases
 func (d *DataPlane) InDomainExternalInForwardingMetrics3(id uint16) {
-	reveal d.WellConfigured()
-	reveal d.getDomExternal()
+	d.WellConfigured()
+	d.getDomExternal()
 	assert unfolding acc(d.Mem(), _) in
 		(unfolding acc(accBatchConn(d.external), _) in true)
 }

--- a/router/dataplane_spec_test.gobra
+++ b/router/dataplane_spec_test.gobra
@@ -201,7 +201,7 @@ func testRun(
 			(next_pair elem domain(dp.links)) &&
 			dp.Lookup(next_pair) == pair
 	assert domain(dp.linkTypes) == domain(dp.neighborIAs)
-	assert reveal dp.Valid()
+	assert dp.Valid()
 	)
 
 	assert dp.Asid().V == 1000
@@ -211,13 +211,13 @@ func testRun(
 	assert d.dpSpecWellConfiguredLinkTypes(dp)
 
 	fold d.Mem()
-	assert d.getDomNeighborIAs() == reveal d.getDomExternal()
+	assert d.getDomNeighborIAs() == d.getDomExternal()
 	assert d.getDomNeighborIAs() == d.getDomLinkTypes()
 	assert !(0 elem d.getDomNeighborIAs())
-	assert reveal d.getDomExternal() intersection d.GetDomInternalNextHops() == set[uint16]{}
-	assert reveal d.DpAgreesWithSpec(dp)
+	assert d.getDomExternal() intersection d.GetDomInternalNextHops() == set[uint16]{}
+	assert d.DpAgreesWithSpec(dp)
 
-	assert reveal d.PreWellConfigured()
+	assert d.PreWellConfigured()
 	fold MutexInvariant!< d !>()
 	// end of foldDataPlaneMem
 	assert !d.IsRunning()

--- a/router/io-spec-abstract-transitions.gobra
+++ b/router/io-spec-abstract-transitions.gobra
@@ -35,7 +35,6 @@ pure func CurrSegIO_ifs(pkt io.Pkt, dir bool) option[io.Ifs] {
 }
 
 ghost
-opaque
 requires oldPkt.PathNotFullyTraversed()
 ensures  newPkt.PathNotFullyTraversed()
 ensures  len(newPkt.CurrSeg.Future) == len(oldPkt.CurrSeg.Future)
@@ -50,7 +49,6 @@ pure func AbsUpdateNonConsDirIngressSegID(oldPkt io.Pkt, ingressID option[io.Ifs
 }
 
 ghost
-opaque
 requires pkt.PathNotFullyTraversed()
 decreases
 pure func AbsValidateIngressIDConstraint(pkt io.Pkt, ingressID option[io.Ifs]) bool {
@@ -60,7 +58,6 @@ pure func AbsValidateIngressIDConstraint(pkt io.Pkt, ingressID option[io.Ifs]) b
 }
 
 ghost
-opaque
 requires pkt.RightSeg != none[io.Seg]
 requires len(get(pkt.RightSeg).Past) > 0
 decreases
@@ -71,7 +68,6 @@ pure func AbsValidateIngressIDConstraintXover(pkt io.Pkt, ingressID option[io.If
 }
 
 ghost
-opaque
 requires pkt.PathNotFullyTraversed()
 decreases
 pure func AbsEgressInterfaceConstraint(pkt io.Pkt, egressID option[io.Ifs]) bool {
@@ -80,7 +76,6 @@ pure func AbsEgressInterfaceConstraint(pkt io.Pkt, egressID option[io.Ifs]) bool
 }
 
 ghost
-opaque
 requires dp.Valid()
 requires pkt.PathNotFullyTraversed()
 decreases
@@ -90,7 +85,6 @@ pure func AbsValidateEgressIDConstraint(pkt io.Pkt, enter bool, dp io.DataPlaneS
 }
 
 ghost
-opaque
 requires oldPkt.PathNotFullyTraversed()
 ensures  len(newPkt.CurrSeg.Future) >= 0
 decreases
@@ -104,7 +98,6 @@ pure func AbsProcessEgress(oldPkt io.Pkt) (newPkt io.Pkt) {
 }
 
 ghost
-opaque
 requires oldPkt.LeftSeg != none[io.Seg]
 requires len(oldPkt.CurrSeg.Future) == 1
 requires len(get(oldPkt.LeftSeg).Future) > 0
@@ -123,7 +116,6 @@ pure func AbsDoXover(oldPkt io.Pkt) (newPkt io.Pkt) {
 }
 
 ghost
-opaque
 requires  dp.Valid()
 requires  pkt.PathNotFullyTraversed()
 requires  pkt.RightSeg != none[io.Seg]
@@ -137,7 +129,6 @@ pure func AbsValidateEgressIDConstraintXover(pkt io.Pkt, dp io.DataPlaneSpec) bo
 }
 
 ghost
-opaque
 requires pkt.PathNotFullyTraversed()
 decreases
 pure func AbsVerifyCurrentMACConstraint(pkt io.Pkt, dp io.DataPlaneSpec) bool {
@@ -167,11 +158,11 @@ preserves ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>
 ensures   ElemWitness(ioSharedArg.OBufY, egressID, newPkt)
 decreases
 func InternalEnterEvent(oldPkt io.Pkt, ingressID option[io.Ifs], newPkt io.Pkt, egressID option[io.Ifs], ioLock gpointer[gsync.GhostMutex], ioSharedArg SharedArg, dp io.DataPlaneSpec) {
-	reveal AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
-	reveal AbsValidateIngressIDConstraint(oldPkt, ingressID)
-	reveal AbsVerifyCurrentMACConstraint(newPkt, dp)
+	AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
+	AbsValidateIngressIDConstraint(oldPkt, ingressID)
+	AbsVerifyCurrentMACConstraint(newPkt, dp)
 	if(len(newPkt.CurrSeg.Future) != 1) {
-		reveal AbsValidateEgressIDConstraint(newPkt, true, dp)
+		AbsValidateEgressIDConstraint(newPkt, true, dp)
 	}
 	AtomicEnter(oldPkt, ingressID, newPkt, egressID, ioLock, ioSharedArg, dp)
 }
@@ -198,13 +189,13 @@ preserves ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>
 ensures   ElemWitness(ioSharedArg.OBufY, egressID, newPkt)
 decreases
 func ExternalEnterOrExitEvent(oldPkt io.Pkt, ingressID option[io.Ifs], newPkt io.Pkt, egressID option[io.Ifs], ioLock gpointer[gsync.GhostMutex], ioSharedArg SharedArg, dp io.DataPlaneSpec) {
-	reveal dp.Valid()
-	nextPkt := reveal AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
-	reveal AbsValidateIngressIDConstraint(oldPkt, ingressID)
-	reveal AbsVerifyCurrentMACConstraint(nextPkt, dp)
-	reveal AbsEgressInterfaceConstraint(nextPkt, egressID)
-	reveal AbsValidateEgressIDConstraint(nextPkt, (ingressID != none[io.Ifs]), dp)
-	reveal AbsProcessEgress(nextPkt)
+	dp.Valid()
+	nextPkt := AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
+	AbsValidateIngressIDConstraint(oldPkt, ingressID)
+	AbsVerifyCurrentMACConstraint(nextPkt, dp)
+	AbsEgressInterfaceConstraint(nextPkt, egressID)
+	AbsValidateEgressIDConstraint(nextPkt, (ingressID != none[io.Ifs]), dp)
+	AbsProcessEgress(nextPkt)
 	if(ingressID == none[io.Ifs]){
 		AtomicExit(oldPkt, ingressID, newPkt, egressID, ioLock, ioSharedArg, dp)
 	} else {
@@ -239,16 +230,16 @@ preserves ioLock.LockInv() == SharedInv!< dp, ioSharedArg !>
 ensures   ElemWitness(ioSharedArg.OBufY, egressID, newPkt)
 decreases
 func XoverEvent(oldPkt io.Pkt, ingressID option[io.Ifs], newPkt io.Pkt, egressID option[io.Ifs], ioLock gpointer[gsync.GhostMutex], ioSharedArg SharedArg, dp io.DataPlaneSpec) {
-	reveal dp.Valid()
-	intermediatePkt1 := reveal AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
-	intermediatePkt2 := reveal AbsDoXover(intermediatePkt1)
-	reveal AbsValidateIngressIDConstraint(oldPkt, ingressID)
-	reveal AbsVerifyCurrentMACConstraint(intermediatePkt1, dp)
-	reveal AbsVerifyCurrentMACConstraint(intermediatePkt2, dp)
-	reveal AbsValidateEgressIDConstraintXover(intermediatePkt2, dp)
+	dp.Valid()
+	intermediatePkt1 := AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
+	intermediatePkt2 := AbsDoXover(intermediatePkt1)
+	AbsValidateIngressIDConstraint(oldPkt, ingressID)
+	AbsVerifyCurrentMACConstraint(intermediatePkt1, dp)
+	AbsVerifyCurrentMACConstraint(intermediatePkt2, dp)
+	AbsValidateEgressIDConstraintXover(intermediatePkt2, dp)
 	if(egressID != none[io.Ifs]){
-		reveal AbsEgressInterfaceConstraint(intermediatePkt2, egressID)
-		reveal AbsProcessEgress(intermediatePkt2)
+		AbsEgressInterfaceConstraint(intermediatePkt2, egressID)
+		AbsProcessEgress(intermediatePkt2)
 	}
 	AtomicXover(oldPkt, ingressID, newPkt, egressID, ioLock, ioSharedArg, dp)
 }

--- a/router/io-spec-lemmas.gobra
+++ b/router/io-spec-lemmas.gobra
@@ -36,7 +36,7 @@ ensures   slayers.ValidPktMetaHdr(raw) && slayers.IsSupportedPkt(raw) ==>
 decreases
 func absIO_valLemma(raw []byte, ingressID uint16) {
 	if(slayers.ValidPktMetaHdr(raw) && slayers.IsSupportedPkt(raw)){
-		absIO := reveal absIO_val(raw, ingressID)
+		absIO := absIO_val(raw, ingressID)
 		assert absIO.isValPkt
 		assert absIO_val(raw, ingressID).ValPkt_2 == absPkt(raw)
 		absPktFutureLemma(raw)
@@ -51,7 +51,7 @@ ensures  slayers.ValidPktMetaHdr(raw)
 ensures  absPkt(raw).PathNotFullyTraversed()
 decreases
 func absPktFutureLemma(raw []byte) {
-	reveal slayers.ValidPktMetaHdr(raw)
+	slayers.ValidPktMetaHdr(raw)
 	headerOffset := slayers.GetAddressOffset(raw)
 	headerOffsetWithMetaLen := headerOffset + scion.MetaLen
 	assert forall k int :: {&raw[headerOffset:headerOffset+scion.MetaLen][k]} 0 <= k && k < scion.MetaLen ==> &raw[headerOffset:headerOffset+scion.MetaLen][k] == &raw[headerOffset + k]
@@ -68,8 +68,8 @@ func absPktFutureLemma(raw []byte) {
 	prevSegLen := segs.LengthOfPrevSeg(currHfIdx)
 	numINF := segs.NumInfoFields()
 	offset := scion.HopFieldOffset(numINF, prevSegLen, headerOffsetWithMetaLen)
-	pkt := reveal absPkt(raw)
-	assert pkt.CurrSeg == reveal scion.CurrSeg(raw, offset, currInfIdx, currHfIdx-prevSegLen, segLen, headerOffsetWithMetaLen)
+	pkt := absPkt(raw)
+	assert pkt.CurrSeg == scion.CurrSeg(raw, offset, currInfIdx, currHfIdx-prevSegLen, segLen, headerOffsetWithMetaLen)
 	assert pkt.PathNotFullyTraversed()
 }
 
@@ -80,9 +80,9 @@ requires  newPkt == AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
 ensures   AbsValidateIngressIDConstraint(newPkt, ingressID)
 decreases
 func AbsValidateIngressIDLemma(oldPkt io.Pkt, newPkt io.Pkt, ingressID option[io.Ifs]) {
-	reveal AbsValidateIngressIDConstraint(oldPkt, ingressID)
-	reveal AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
-	reveal AbsValidateIngressIDConstraint(newPkt, ingressID)
+	AbsValidateIngressIDConstraint(oldPkt, ingressID)
+	AbsUpdateNonConsDirIngressSegID(oldPkt, ingressID)
+	AbsValidateIngressIDConstraint(newPkt, ingressID)
 }
 
 ghost
@@ -95,13 +95,12 @@ requires  newPkt == AbsDoXover(oldPkt)
 ensures   AbsValidateIngressIDConstraintXover(newPkt, ingressID)
 decreases
 func AbsValidateIngressIDXoverLemma(oldPkt io.Pkt, newPkt io.Pkt, ingressID option[io.Ifs]) {
-	reveal AbsValidateIngressIDConstraint(oldPkt, ingressID)
-	reveal AbsDoXover(oldPkt)
-	reveal AbsValidateIngressIDConstraintXover(newPkt, ingressID)
+	AbsValidateIngressIDConstraint(oldPkt, ingressID)
+	AbsDoXover(oldPkt)
+	AbsValidateIngressIDConstraintXover(newPkt, ingressID)
 }
 
 ghost
-opaque
 requires p.scionLayer.Mem(ub)
 requires acc(&p.d) && p.d.Mem()
 requires acc(&p.ingressID)
@@ -113,7 +112,6 @@ pure func (p *scionPacketProcessor) DstIsLocalIngressID(ub []byte) bool {
 }
 
 ghost
-opaque
 requires p.scionLayer.Mem(ub)
 requires acc(&p.d) && p.d.Mem()
 requires acc(&p.ingressID)
@@ -147,8 +145,8 @@ ensures  p.ingressID != 0
 ensures  len(absPkt(ub).CurrSeg.Future) == 1
 decreases
 func (p* scionPacketProcessor) LocalDstLemma(ub []byte) {
-	reveal p.DstIsLocalIngressID(ub)
-	reveal p.LastHopLen(ub)
+	p.DstIsLocalIngressID(ub)
+	p.LastHopLen(ub)
 }
 
 ghost
@@ -162,7 +160,6 @@ pure func (p* scionPacketProcessor) GetIsXoverSpec(ub []byte) bool {
 }
 
 ghost
-opaque
 requires acc(&p.d) && p.d.Mem()
 requires acc(&p.ingressID)
 requires pkt.PathNotFullyTraversed()
@@ -185,8 +182,8 @@ ensures  acc(&p.ingressID, R55)
 ensures  p.NoBouncingPkt(pkt)
 decreases
 func (p *scionPacketProcessor) EstablishNoBouncingPkt(pkt io.Pkt, egressID uint16) {
-	reveal AbsEgressInterfaceConstraint(pkt, path.ifsToIO_ifs(egressID))
-	reveal p.NoBouncingPkt(pkt)
+	AbsEgressInterfaceConstraint(pkt, path.ifsToIO_ifs(egressID))
+	p.NoBouncingPkt(pkt)
 }
 
 ghost
@@ -201,8 +198,8 @@ ensures  acc(&p.ingressID, R55)
 ensures  p.ingressID != 0
 decreases
 func (p *scionPacketProcessor) IngressIDNotZeroLemma(pkt io.Pkt, egressID uint16) {
-	reveal AbsEgressInterfaceConstraint(pkt, path.ifsToIO_ifs(egressID))
-	reveal p.NoBouncingPkt(pkt)
+	AbsEgressInterfaceConstraint(pkt, path.ifsToIO_ifs(egressID))
+	p.NoBouncingPkt(pkt)
 }
 
 ghost
@@ -231,9 +228,9 @@ func (p* scionPacketProcessor) EstablishEqAbsHeader(ub []byte, start int, end in
 	unfold acc(sl.Bytes(ub[start:end], 0, len(ub[start:end])), R56)
 	unfold acc(p.scionLayer.Mem(ub), R56)
 	unfold acc(p.path.Mem(ub[start:end]), R56)
-	reveal p.scionLayer.EqAbsHeader(ub)
-	reveal p.scionLayer.ValidScionInitSpec(ub)
-	assert reveal p.scionLayer.ValidHeaderOffset(ub, len(ub))
+	p.scionLayer.EqAbsHeader(ub)
+	p.scionLayer.ValidScionInitSpec(ub)
+	assert p.scionLayer.ValidHeaderOffset(ub, len(ub))
 	assert p.path.GetBase(ub[start:end]).EqAbsHeader(ub[start:end])
 	fold acc(p.path.Mem(ub[start:end]), R56)
 	fold acc(p.scionLayer.Mem(ub), R56)
@@ -269,11 +266,11 @@ decreases
 func (p* scionPacketProcessor) AbsPktToSubSliceAbsPkt(ub []byte, start int, end int) {
 	unfold acc(sl.Bytes(ub, 0, len(ub)), R56)
 	unfold acc(sl.Bytes(ub[start:end], 0, len(ub[start:end])), R56)
-	reveal slayers.ValidPktMetaHdr(ub)
-	reveal p.scionLayer.EqAbsHeader(ub)
-	assert reveal scion.validPktMetaHdr(ub[start:end])
+	slayers.ValidPktMetaHdr(ub)
+	p.scionLayer.EqAbsHeader(ub)
+	assert scion.validPktMetaHdr(ub[start:end])
 	unfold acc(p.scionLayer.Mem(ub), R56)
-	reveal p.scionLayer.ValidHeaderOffset(ub, len(ub))
+	p.scionLayer.ValidHeaderOffset(ub, len(ub))
 	assert p.path.GetBase(ub[start:end]).EqAbsHeader(ub[start:end])
 	fold acc(p.scionLayer.Mem(ub), R56)
 	assert start == slayers.GetAddressOffset(ub)
@@ -301,7 +298,7 @@ func (p* scionPacketProcessor) AbsPktToSubSliceAbsPkt(ub []byte, start int, end 
 	scion.WidenLeftSeg(ub, currInfIdx + 1, segs, headerOffsetWithMetaLen, start, end)
 	scion.WidenMidSeg(ub, currInfIdx + 2, segs, headerOffsetWithMetaLen, start, end)
 	scion.WidenRightSeg(ub, currInfIdx - 1, segs, headerOffsetWithMetaLen, start, end)
-	assert reveal absPkt(ub) == reveal p.path.absPkt(ub[start:end])
+	assert absPkt(ub) == p.path.absPkt(ub[start:end])
 }
 
 ghost
@@ -334,12 +331,12 @@ func (p* scionPacketProcessor) SubSliceAbsPktToAbsPkt(ub []byte, start int, end 
 	unfold acc(sl.Bytes(ub[start:end], 0, len(ub[start:end])), R56)
 	unfold acc(p.scionLayer.Mem(ub), R56)
 	unfold acc(p.scionLayer.Path.Mem(ub[start:end]), R56)
-	reveal p.scionLayer.ValidHeaderOffset(ub, len(ub))
-	assert reveal p.scionLayer.EqAbsHeader(ub)
+	p.scionLayer.ValidHeaderOffset(ub, len(ub))
+	assert p.scionLayer.EqAbsHeader(ub)
 	fold acc(p.scionLayer.Path.Mem(ub[start:end]), R56)
 	fold acc(p.scionLayer.Mem(ub), R56)
-	reveal scion.validPktMetaHdr(ub[start:end])
-	assert reveal slayers.ValidPktMetaHdr(ub)
+	scion.validPktMetaHdr(ub[start:end])
+	assert slayers.ValidPktMetaHdr(ub)
 	assert start == slayers.GetAddressOffset(ub)
 	headerOffsetWithMetaLen := start + scion.MetaLen
 	hdr1 := binary.BigEndian.Uint32(ub[start:start+scion.MetaLen])
@@ -365,11 +362,10 @@ func (p* scionPacketProcessor) SubSliceAbsPktToAbsPkt(ub []byte, start int, end 
 	scion.WidenLeftSeg(ub, currInfIdx + 1, segs, headerOffsetWithMetaLen, start, end)
 	scion.WidenMidSeg(ub, currInfIdx + 2, segs, headerOffsetWithMetaLen, start, end)
 	scion.WidenRightSeg(ub, currInfIdx - 1, segs, headerOffsetWithMetaLen, start, end)
-	assert reveal absPkt(ub) == reveal p.path.absPkt(ub[start:end])
+	assert absPkt(ub) == p.path.absPkt(ub[start:end])
 }
 
 ghost
-opaque
 requires acc(&p.hopField)
 requires pkt.PathNotFullyTraversed()
 decreases
@@ -380,7 +376,6 @@ pure func (p* scionPacketProcessor) EqAbsHopField(pkt io.Pkt) bool {
 }
 
 ghost
-opaque
 requires acc(&p.infoField)
 decreases
 pure func (p* scionPacketProcessor) EqAbsInfoField(pkt io.Pkt) bool {

--- a/router/io-spec.gobra
+++ b/router/io-spec.gobra
@@ -31,12 +31,11 @@ import (
 )
 
 ghost
-opaque
 requires sl.Bytes(raw, 0, len(raw))
 requires slayers.ValidPktMetaHdr(raw)
 decreases
 pure func absPkt(raw []byte) (res io.Pkt) {
-	return let _ := reveal slayers.ValidPktMetaHdr(raw) in
+	return let _ := slayers.ValidPktMetaHdr(raw) in
 		let headerOffset := slayers.GetAddressOffset(raw) in
 		let headerOffsetWithMetaLen := headerOffset + scion.MetaLen in
 		let hdr := (unfolding sl.Bytes(raw, 0, len(raw)) in
@@ -73,12 +72,11 @@ pure func absValUnsupported(raw []byte, ingressID uint16) (val io.Val) {
 }
 
 ghost
-opaque
 requires sl.Bytes(raw, 0, len(raw))
 ensures val.isValPkt || val.isValUnsupported
 decreases
 pure func absIO_val(raw []byte, ingressID uint16) (val io.Val) {
-	return (reveal slayers.ValidPktMetaHdr(raw) && slayers.IsSupportedPkt(raw)) ?
+	return (slayers.ValidPktMetaHdr(raw) && slayers.IsSupportedPkt(raw)) ?
 		io.Val(io.ValPkt{path.ifsToIO_ifs(ingressID), absPkt(raw)}) :
 		absValUnsupported(raw, ingressID)
 }
@@ -90,7 +88,7 @@ ensures  acc(sl.Bytes(raw, 0, len(raw)), R56)
 ensures  absIO_val(raw, ingressID).isValUnsupported
 decreases
 func AbsUnsupportedPktIsUnsupportedVal(raw []byte, ingressID uint16) {
-	reveal absIO_val(raw, ingressID)
+	absIO_val(raw, ingressID)
 }
 
 ghost
@@ -140,7 +138,6 @@ pure func (d *DataPlane) dpSpecWellConfiguredLinkTypes(dp io.DataPlaneSpec) bool
 }
 
 ghost
-opaque
 requires d.Mem()
 decreases
 pure func (d *DataPlane) DpAgreesWithSpec(dp io.DataPlaneSpec) bool {
@@ -159,8 +156,8 @@ ensures  d.linkTypes != nil ==> acc(d.linkTypes, _) && !(0 elem domain(d.linkTyp
 ensures  d.dpSpecWellConfiguredLinkTypes(dp)
 decreases
 func (d *DataPlane) LinkTypesLemma(dp io.DataPlaneSpec) {
-	reveal d.WellConfigured()
-	reveal d.DpAgreesWithSpec(dp)
+	d.WellConfigured()
+	d.DpAgreesWithSpec(dp)
 	assert !(0 elem d.getDomLinkTypes())
 	unfold acc(d.Mem(), _)
 	assert !(0 elem domain(d.linkTypes))
@@ -175,8 +172,8 @@ ensures  egressID != 0
 ensures  io.Ifs{egressID} elem domain(dp.GetNeighborIAs())
 decreases
 func (d *DataPlane) EgressIDNotZeroLemma(egressID uint16, dp io.DataPlaneSpec) {
-	reveal d.WellConfigured()
-	reveal d.DpAgreesWithSpec(dp)
+	d.WellConfigured()
+	d.DpAgreesWithSpec(dp)
 }
 
 ghost
@@ -190,11 +187,11 @@ ensures  d.getDomExternal() == domain(d.external)
 decreases
 func (d *DataPlane) getDomExternalLemma() {
 	if (d.external != nil) {
-		assert reveal d.getDomExternal() == unfolding acc(d.Mem(), _) in
+		assert d.getDomExternal() == unfolding acc(d.Mem(), _) in
 			(unfolding acc(accBatchConn(d.external), _) in
 					domain(d.external))
 	} else {
-		assert reveal d.getDomExternal() ==
+		assert d.getDomExternal() ==
 			unfolding acc(d.Mem(), _) in set[uint16]{}
 	}
 }

--- a/router/widen-lemma.gobra
+++ b/router/widen-lemma.gobra
@@ -50,13 +50,13 @@ func absIO_valWidenLemma(raw []byte, ingressID uint16, length int) {
 
 		ret1 = io.Val(io.ValPkt{path.ifsToIO_ifs(ingressID), absPkt(raw)})
 		ret2 = io.Val(io.ValPkt{path.ifsToIO_ifs(ingressID), absPkt(raw[:length])})
-		assert ret1 == reveal absIO_val(raw, ingressID)
-		assert ret2 == reveal absIO_val(raw[:length], ingressID)
+		assert ret1 == absIO_val(raw, ingressID)
+		assert ret2 == absIO_val(raw[:length], ingressID)
 		assert ret1 == ret2
 		assert absIO_val(raw[:length], ingressID).isValPkt ==>
 			absIO_val(raw[:length], ingressID) == absIO_val(raw, ingressID)
 	} else {
-		assert !(reveal absIO_val(raw[:length], ingressID).isValPkt)
+		assert !(absIO_val(raw[:length], ingressID).isValPkt)
 	}
 }
 
@@ -72,9 +72,9 @@ decreases
 func ValidPktMetaHdrWidenLemma(raw []byte, length int) {
 	unfold acc(sl.Bytes(raw, 0, len(raw)), R56)
 	unfold acc(sl.Bytes(raw[:length], 0, len(raw[:length])), R56)
-	reveal slayers.ValidPktMetaHdr(raw[:length])
-	ret1 := reveal slayers.ValidPktMetaHdr(raw)
-	ret2 := reveal slayers.ValidPktMetaHdr(raw[:length])
+	slayers.ValidPktMetaHdr(raw[:length])
+	ret1 := slayers.ValidPktMetaHdr(raw)
+	ret2 := slayers.ValidPktMetaHdr(raw[:length])
 	assert ret1 == ret2
 	fold acc(sl.Bytes(raw, 0, len(raw)), R56)
 	fold acc(sl.Bytes(raw[:length], 0, len(raw[:length])), R56)
@@ -92,9 +92,9 @@ decreases
 func IsSupportedPktWidenLemma(raw []byte, length int) {
 	unfold acc(sl.Bytes(raw, 0, len(raw)), R56)
 	unfold acc(sl.Bytes(raw[:length], 0, len(raw[:length])), R56)
-	reveal slayers.IsSupportedPkt(raw[:length])
-	ret1 := reveal slayers.IsSupportedPkt(raw)
-	ret2 := reveal slayers.IsSupportedPkt(raw[:length])
+	slayers.IsSupportedPkt(raw[:length])
+	ret1 := slayers.IsSupportedPkt(raw)
+	ret2 := slayers.IsSupportedPkt(raw[:length])
 	assert ret1 == ret2
 	fold acc(sl.Bytes(raw, 0, len(raw)), R56)
 	fold acc(sl.Bytes(raw[:length], 0, len(raw[:length])), R56)
@@ -114,8 +114,8 @@ ensures  absPkt(raw) == absPkt(raw[:length])
 decreases
 func absPktWidenLemma(raw []byte, length int) {
 
-	reveal slayers.ValidPktMetaHdr(raw)
-	reveal slayers.ValidPktMetaHdr(raw[:length])
+	slayers.ValidPktMetaHdr(raw)
+	slayers.ValidPktMetaHdr(raw[:length])
 	unfold acc(sl.Bytes(raw, 0, len(raw)), R51)
 	unfold acc(sl.Bytes(raw[:length], 0, len(raw[:length])), R51)
 	headerOffset1 := slayers.GetAddressOffset(raw)
@@ -147,5 +147,5 @@ func absPktWidenLemma(raw []byte, length int) {
 	scion.WidenMidSeg(raw, currInfIdx + 2, segs, headerOffsetWithMetaLen, 0, length)
 	scion.WidenRightSeg(raw, currInfIdx - 1, segs, headerOffsetWithMetaLen, 0, length)
 
-	assert reveal absPkt(raw) == reveal absPkt(raw[:length])
+	assert absPkt(raw) == absPkt(raw[:length])
 }

--- a/verification/io/dataplane_abstract.gobra
+++ b/verification/io/dataplane_abstract.gobra
@@ -32,7 +32,6 @@ ghost type AsIfsPair ghost struct {
 }
 
 ghost
-opaque
 decreases
 pure func (dp DataPlaneSpec) Valid() bool {
 	return (forall ifs Ifs :: {ifs elem domain(dp.neighborIAs)} ifs elem domain(dp.neighborIAs)  ==>

--- a/verification/io/other_defs.gobra
+++ b/verification/io/other_defs.gobra
@@ -185,7 +185,6 @@ pure func (dp DataPlaneSpec) if_type(asid AS, ifs option[Ifs], link Link) bool{
 }
 
 ghost
-opaque
 decreases
 pure func (m MsgTerm) extract_asid() AS {
 	return m.MsgTerm_Hash_.MsgTerm_MPair_1.MsgTerm_Key_.Key_macK_

--- a/verification/io/router.gobra
+++ b/verification/io/router.gobra
@@ -48,13 +48,12 @@ pure func hf_valid_impl(asid AS, ts uint, uinfo set[MsgTerm], hf HF) bool {
 }
 
 ghost
-opaque
 ensures result.extract_asid() == asid
 decreases
 pure func nextMsgtermSpec(asid AS, inif option[Ifs], egif option[Ifs], ts uint, uinfo set[MsgTerm]) (result MsgTerm) {
 	return let l := plaintextToMac(inif, egif, ts, uinfo) in
 		let res := mac(macKey(asidToKey(asid)), l) in
-		let _ := reveal res.extract_asid() in
+		let _ := res.extract_asid() in
 		res
 }
 
@@ -149,7 +148,7 @@ requires len(m.CurrSeg.Future) > 0
 requires dp.Valid()
 decreases
 pure func (dp DataPlaneSpec) dp3s_forward_ext(m Pkt, newpkt Pkt, nextif Ifs) bool {
-	return let _ := reveal dp.Valid() in
+	return let _ := dp.Valid() in
 		let currseg := m.CurrSeg in
 		let hf1, fut := currseg.Future[0], currseg.Future[1:] in
 		let traversedseg := newpkt.CurrSeg in
@@ -165,7 +164,7 @@ requires len(m.CurrSeg.Future) > 0
 requires dp.Valid()
 decreases
 pure func (dp DataPlaneSpec) dp3s_forward_ext_xover(m Pkt, newpkt Pkt, nextif Ifs) bool {
-	return let _ := reveal dp.Valid() in
+	return let _ := dp.Valid() in
 		let currseg := m.CurrSeg in
 		let hf1, fut := currseg.Future[0], currseg.Future[1:] in
 		let traversedseg := newpkt.CurrSeg in

--- a/verification/utils/monoset/monoset.gobra
+++ b/verification/utils/monoset/monoset.gobra
@@ -173,7 +173,6 @@ func Alloc(start, end int64) (res BoundedMonotonicSet) {
 }
 
 ghost
-opaque // make this closed when that is supported
 requires b.Inv()
 decreases
 pure func (b BoundedMonotonicSet) ToSet() set[int64] {
@@ -203,7 +202,7 @@ func (b BoundedMonotonicSet) ContainsImpliesAbstractContains(v int64, p perm) {
 	found := false
 	i := b.Start
 	part1 := set[int64]{}
-	part2 := reveal b.ToSet()
+	part2 := b.ToSet()
 
 	assert unfolding b.Contains(v) in b.Start <= v && v <= b.End
 
@@ -252,7 +251,7 @@ func (b BoundedMonotonicSet) DoesNotContainsImpliesAbstractDoesNotContain(v int6
 	found := false
 	i := int64(0)
 	part1 := set[int64]{}
-	part2 := reveal b.ToSet()
+	part2 := b.ToSet()
 
 	assert unfolding b.DoesNotContain(v) in b.Start <= v && v <= b.End
 


### PR DESCRIPTION
## Summary
This PR removes `opaque` annotations from numerous ghost functions throughout the codebase. The `opaque` keyword in Gobra is used to hide function implementations from callers, but these annotations are being systematically removed and replaced with direct function calls (removing `reveal` statements).

## Key Changes

- **Removed `opaque` annotations** from ghost function definitions across multiple files:
  - `router/dataplane.go`: Removed from `PreWellConfigured()`, `getDomExternal()`, `DpAgreesWithSpec()`, and others
  - `pkg/slayers/path/scion/raw_spec.gobra`: Removed from segment, path, and validation functions
  - `router/io-spec-abstract-transitions.gobra`: Removed from constraint and transition functions
  - `router/dataplane_spec.gobra`: Removed from `getDomExternal()`, `WellConfigured()`, `PreWellConfigured()`, and others
  - `pkg/slayers/scion_spec.gobra`: Removed from header validation and packet support functions
  - `verification/io/dataplane_abstract.gobra`: Removed from `Valid()`
  - `verification/io/other_defs.gobra`: Removed from `extract_asid()`

- **Replaced `reveal` calls with direct function calls**: Throughout the codebase, instances of `reveal function_name()` have been replaced with direct calls `function_name()`, making the code more straightforward and removing the need for explicit revelation of opaque functions.

- **Affected files**: Changes span across router logic, SCION path handling, verification specifications, and utility functions.

## Implementation Details

The removal of `opaque` annotations makes ghost function implementations visible to callers, which simplifies the verification code by eliminating the need for explicit `reveal` statements. This change appears to be part of a broader refactoring to improve code clarity and reduce verification complexity without changing the actual logic or behavior of the functions.

https://claude.ai/code/session_012ZFij5qKMsuxVzKph8gbX3